### PR TITLE
Add main menu link buttons support

### DIFF
--- a/mss32/include/interfaceutils.h
+++ b/mss32/include/interfaceutils.h
@@ -21,6 +21,7 @@
 #define INTERFACEUTILS_H
 
 #include "menubase.h"
+#include "textids.h"
 #include <string>
 
 namespace game {
@@ -97,6 +98,10 @@ void setEditBoxText(game::CDialogInterf* dialog,
                     const char* editName,
                     const char* text,
                     bool moveCursorPos);
+void openInBrowser(const std::string& url);
+std::string resolveLink(const hooks::LinkItem& item);
+bool hasControl(game::CDialogInterf* dialog, const char* name);
+
 
 } // namespace hooks
 

--- a/mss32/include/menucustommain.h
+++ b/mss32/include/menucustommain.h
@@ -34,7 +34,8 @@ class CMenuCustomMain
 public:
     static constexpr char loginAccountDialogName[] = "DLG_LOGIN_ACCOUNT";
     static constexpr char registerAccountDialogName[] = "DLG_REGISTER_ACCOUNT";
-
+    
+    static void __fastcall linkBtnHandler(game::CMenuBase* param, int);
     CMenuCustomMain(game::CMenuPhase* menuPhase);
     ~CMenuCustomMain();
 
@@ -43,7 +44,9 @@ protected:
     static void __fastcall destructor(CMenuCustomMain* thisptr, int /*%edx*/, char flags);
 
     static void __fastcall tutorialBtnHandler(CMenuCustomMain* thisptr, int /*%edx*/);
-
+    void bindLinkButton(game::CDialogInterf* dialog,
+                        const char* buttonName,
+                        const std::string& url);
     void showLoginDialog();
     void hideLoginDialog();
     void showRegisterDialog();
@@ -116,6 +119,7 @@ private:
     LobbyCallback m_lobbyCallback;
     CLoginAccountInterf* m_loginDialog;
     CRegisterAccountInterf* m_registerDialog;
+    std::vector<std::string> m_linkStorage;
 };
 
 assert_offset(CMenuCustomMain, vftable, 0);

--- a/mss32/include/textids.h
+++ b/mss32/include/textids.h
@@ -21,8 +21,15 @@
 #define TEXTIDS_H
 
 #include <string>
+#include <vector>
 
 namespace hooks {
+
+struct LinkItem
+{
+    std::string textId;
+    std::string fallback;
+};
 
 struct TextIds
 {
@@ -62,6 +69,7 @@ struct TextIds
         std::string infiniteText;
         std::string removedAttackWard;
         std::string currentTurn;
+        std::vector<LinkItem> mainMenuLinks;
     } interf;
 
     struct Events

--- a/mss32/src/interfaceutils.cpp
+++ b/mss32/src/interfaceutils.cpp
@@ -41,6 +41,7 @@
 #include "usunitimpl.h"
 #include "utils.h"
 #include <fmt/format.h>
+#include <windows.h>
 
 namespace hooks {
 
@@ -465,6 +466,67 @@ void setButtonCallback(game::CDialogInterf* dialog,
     CButtonInterfApi::get().assignFunctor(dialog, buttonName, dialog->data->dialogName, &functor,
                                           0);
     SmartPointerApi::get().createOrFreeNoDtor(&functor, nullptr);
+}
+
+void openInBrowser(const std::string& url)
+{
+    if (url.empty())
+        return;
+
+    std::string command = "cmd /c start \"\" \"" + url + "\"";
+
+    STARTUPINFOA si{};
+    PROCESS_INFORMATION pi{};
+    si.cb = sizeof(si);
+
+    if (CreateProcessA(nullptr, command.data(), nullptr, nullptr, FALSE, CREATE_NO_WINDOW, nullptr,
+                       nullptr, &si, &pi)) {
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+    }
+}
+static bool isValidUrl(const std::string& str)
+{
+    return str.find("http://") == 0 || str.find("https://") == 0 || str.find("www.") == 0;
+}
+
+std::string resolveLink(const hooks::LinkItem& item)
+{
+
+    std::string result;
+
+    if (!item.textId.empty()) {
+        auto text = getInterfaceText(item.textId.c_str());
+
+        if (!text.empty() && isValidUrl(text)) {
+            result = text;
+        }
+    }
+
+    if (result.empty() && !item.fallback.empty()) {
+        if (isValidUrl(item.fallback)) {
+            result = item.fallback;
+        }
+    }
+
+    return result;
+}
+
+bool hasControl(game::CDialogInterf* dialog, const char* name)
+{
+    using namespace game;
+
+    if (!dialog || !dialog->data)
+        return false;
+
+    auto& tree = dialog->data->childControls;
+
+    for (auto it = tree.begin(); it != tree.end(); ++it) {
+        if (strcmp(it->first, name) == 0)
+            return true;
+    }
+
+    return false;
 }
 
 void setButtonCallback(game::CButtonInterf* button, void* callback, void* callbackParam)

--- a/mss32/src/menucustommain.cpp
+++ b/mss32/src/menucustommain.cpp
@@ -30,13 +30,49 @@
 #include "restrictions.h"
 #include "settings.h"
 #include "textboxinterf.h"
-#include "textids.h"
 #include "utils.h"
 #include <spdlog/spdlog.h>
 
 namespace hooks {
+    
+void __fastcall CMenuCustomMain::linkBtnHandler(game::CMenuBase* param, int)
+{
+    auto url = reinterpret_cast<std::string*>(param);
 
-CMenuCustomMain::CMenuCustomMain(game::CMenuPhase* menuPhase)
+    std::string finalUrl;
+
+    if (url && !url->empty()) {
+        finalUrl = *url;
+    } else {
+        static const char* fallbackUrls[] =
+            {"https://ru.wikipedia.org/wiki/Disciples_II:_Dark_Prophecy",
+             "https://www.gog.com/en/game/disciples_2_gold",
+             "https://github.com/VladimirMakeev/D2ModdingToolset"};
+
+        finalUrl = fallbackUrls[rand() % 3];
+    }
+
+    openInBrowser(finalUrl);
+}
+
+void CMenuCustomMain::bindLinkButton(game::CDialogInterf* dialog,
+                                     const char* buttonName,
+                                     const std::string& url)
+{
+    using namespace game;
+
+    auto button = CDialogInterfApi::get().findButton(dialog, buttonName);
+    if (!button)
+        return;
+
+    m_linkStorage.push_back(url);
+
+    std::string* urlPtr = &m_linkStorage.back();
+
+    hooks::setButtonCallback(button, (void*)CMenuCustomMain::linkBtnHandler, (void*)urlPtr);
+}
+
+    CMenuCustomMain::CMenuCustomMain(game::CMenuPhase* menuPhase)
     : CMenuCustomBase{this}
     , m_peerCallback{this}
     , m_lobbyCallback{this}
@@ -66,6 +102,22 @@ CMenuCustomMain::CMenuCustomMain(game::CMenuPhase* menuPhase)
 
     // Since original button does not work anyway, this is the ideal spot
     setButtonCallback(dialog, "BTN_TUTORIAL", tutorialBtnHandler, this);
+
+    const auto& links = textIds().interf.mainMenuLinks;
+
+    m_linkStorage.clear();
+    m_linkStorage.reserve(links.size());
+
+    for (size_t i = 0; i < links.size() && i < 20; ++i) {
+        std::string name = fmt::format("BTN_LINK_{}", i + 1);
+
+        if (!hasControl(dialog, name.c_str()))
+            continue;
+
+        std::string url = resolveLink(links[i]);
+
+        bindLinkButton(dialog, name.c_str(), url);
+    }
 }
 
 CMenuCustomMain ::~CMenuCustomMain()

--- a/mss32/src/textids.cpp
+++ b/mss32/src/textids.cpp
@@ -211,6 +211,18 @@ void readInterfTextIds(const sol::table& table, TextIds::Interf& value)
     value.infiniteText = interf.value().get_or("infiniteText", std::string());
     value.removedAttackWard = interf.value().get_or("removedAttackWard", std::string());
     value.currentTurn = interf.value().get_or("currentTurn", std::string());
+    auto links = interf.value().get<sol::optional<sol::table>>("mainMenuLinks");
+    if (links.has_value()) {
+        for (auto& kv : links.value()) {
+            auto entry = kv.second.as<sol::table>();
+
+            hooks::LinkItem item;
+            item.textId = entry.get_or("textId", std::string());
+            item.fallback = entry.get_or("fallback", std::string());
+
+            value.mainMenuLinks.push_back(item);
+        }
+    }
 }
 
 void initialize(TextIds& value)


### PR DESCRIPTION
Implemented support for custom main menu link buttons.

- Added up to 20 configurable buttons (BTN_LINK_1 ... BTN_LINK_20) in DLG_MAIN_MENU
- Linked buttons to external URLs via textids.lua (interf.mainMenuLinks)
- Implemented logic for opening links from the game UI
- Updated interface and text handling (interfaceutils, menucustommain, textids)