### PR TITLE
Add begin turn hook with Lua callback support

### DIFF
--- a/Scripts/turn.lua
+++ b/Scripts/turn.lua
@@ -5,3 +5,16 @@
 function processTurnZero()
 
 end
+
+
+--[[
+    Called at the start of each player turn, including neutrals
+    Executed on host-side
+    Allows running custom per-turn logic
+--]]
+function processTurnStart(player)
+ -- player id log(tostring(player.id))
+ -- race category id log(tostring(player.race))
+ -- any custom logic log("Custom turn logic executed")
+
+ end

--- a/mss32/include/game.h
+++ b/mss32/include/game.h
@@ -86,6 +86,7 @@ struct LSiteCategory;
 struct CMidSite;
 struct CTextBoxInterf;
 struct CCmdNobleResultMsg;
+struct CMidServerLogicData;
 
 enum class ModifierElementTypeFlag : int;
 
@@ -775,6 +776,19 @@ using GetSideshowUnitImpl = game::CMidgardID*(__thiscall*)(TRaceType* thisptr,
 using FindCapitalByPlayerId = game::CFortification*(__stdcall*)(game::CMidgardID* playerId,
                                                                 game::IMidgardObjectMap* objectMap);
 
+/**
+ * Called when a player's turn begins.
+ *
+ * Executes core begin turn logic inside CMidServerLogicData.
+ * Invoked for all players, including neutral factions.
+ *
+ * @param thisptr Pointer to server logic data instance.
+ * @param playerId Identifier of the player whose turn is starting.
+ */
+using MidServerLogicDataBeginTurn = void(__thiscall*)(CMidServerLogicData* thisptr,
+                                                      CMidgardID* playerId);
+
+
 /** Game and editor functions that can be hooked. */
 struct Functions
 {
@@ -914,6 +928,7 @@ struct Functions
     AddSideshowUnitToUI addSideshowUnitToUI;
     GetSideshowUnitImpl getSideshowUnitImpl;
     FindCapitalByPlayerId findCapitalByPlayerId;
+    MidServerLogicDataBeginTurn midServerLogicDataBeginTurn;
 };
 
 /** Global variables used in game. */

--- a/mss32/include/racetype.h
+++ b/mss32/include/racetype.h
@@ -58,11 +58,42 @@ struct CRacePlayerDesc
     char unknown[18];
 };
 
-/** Holds city information read from GCityInf.dbf. */
-struct TRaceTypeCityInformation;
+struct TRaceTypeCityTierData
+{
+    int scout;                       /**< Fog reveal radius after city recalculation. */
+    int regen;                       /**< REGEN_F field from GCityInf.dbf. */
+    CMidgardID protectionModifierId; /**< PROTECTION field from GCityInf.dbf. */
+    int resourceMultiplier;          /**< RES_M field from GCityInf.dbf. */
+    Bank upgradePrice;               /**< GROWTH field from GCityInf.dbf. */
+    int padding;
+};
 
+assert_size(TRaceTypeCityTierData, 32);
+
+/** Internal lookup entry used by TRaceTypeCityInformation. */
+struct TRaceTypeCityTierEntry
+{
+    int tier;
+    TRaceTypeCityTierData* data;
+};
+
+assert_size(TRaceTypeCityTierEntry, 8);
+
+
+
+/** Holds city information read from GCityInf.dbf. */
+struct TRaceTypeCityInformation
+{
+    TRaceTypeCityTierEntry** entries;
+};
+
+assert_size(TRaceTypeCityInformation, 4);
+
+
+    
 struct TRaceTypeData
 {
+    //
     LRaceCategory raceType;
     TextAndId name;
     bool playable;

--- a/mss32/include/turnhooks.h
+++ b/mss32/include/turnhooks.h
@@ -1,0 +1,22 @@
+#ifndef TURNHOOKS_H
+#define TURNHOOKS_H
+
+#include "phasegame.h"
+
+namespace game {
+
+struct CMidServerLogicData;
+
+struct CMidgardID;
+
+} // namespace game
+
+namespace hooks {
+
+void* getBeginTurnHooked();
+
+void** getBeginTurnOrig();
+
+} // namespace hooks
+
+#endif

--- a/mss32/mss32.vcxproj
+++ b/mss32/mss32.vcxproj
@@ -596,6 +596,7 @@ call ..\buildDetours.bat ..\Detours
     <ClCompile Include="src\trainingcampinterf.cpp" />
     <ClCompile Include="src\transformotherhooks.cpp" />
     <ClCompile Include="src\transformselfhooks.cpp" />
+    <ClCompile Include="src\turnhooks.cpp" />
     <ClCompile Include="src\uievent.cpp" />
     <ClCompile Include="src\uimanager.cpp" />
     <ClCompile Include="src\umattack.cpp" />
@@ -1331,6 +1332,7 @@ call ..\buildDetours.bat ..\Detours
     <ClInclude Include="include\textmessage.h" />
     <ClInclude Include="include\timer.h" />
     <ClInclude Include="include\trainingcampinterf.h" />
+    <ClInclude Include="include\turnhooks.h" />
     <ClInclude Include="include\unitsforhirehooks.h" />
     <ClInclude Include="include\visitorcreatesite.h" />
     <ClInclude Include="include\visitorcreatesitehooks.h" />

--- a/mss32/mss32.vcxproj.filters
+++ b/mss32/mss32.vcxproj.filters
@@ -1576,6 +1576,9 @@
     <ClCompile Include="src\bindings\globalunitsview.cpp">
       <Filter>bindings</Filter>
     </ClCompile>
+    <ClCompile Include="src\turnhooks.cpp">
+      <Filter>hooks</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\aipriority.h">
@@ -3929,6 +3932,9 @@
     <ClInclude Include="include\batattackboostdamage.h" />
     <ClInclude Include="include\bindings\globalunitsview.h">
       <Filter>bindings</Filter>
+    </ClInclude>
+    <ClInclude Include="include\turnhooks.h">
+      <Filter>hooks</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/mss32/src/game.cpp
+++ b/mss32/src/game.cpp
@@ -161,6 +161,7 @@ static std::array<Functions, 4> functions = {{
         (AddSideshowUnitToUI)0x4b5222,
         (GetSideshowUnitImpl)0x582c8b,
         (FindCapitalByPlayerId)0x5ea751,
+        (MidServerLogicDataBeginTurn)0x41e7a8,
     },
     // Russobit
     Functions{
@@ -298,6 +299,7 @@ static std::array<Functions, 4> functions = {{
         (AddSideshowUnitToUI)0x4b5222,
         (GetSideshowUnitImpl)0x582c8b,
         (FindCapitalByPlayerId)0x5ea751,
+        (MidServerLogicDataBeginTurn)0x41e7a8,
     },
     // Gog
     Functions{
@@ -435,6 +437,7 @@ static std::array<Functions, 4> functions = {{
         (AddSideshowUnitToUI)0x4b48bb,
         (GetSideshowUnitImpl)0x581ee1,
         (FindCapitalByPlayerId)0x5e9450,
+        (MidServerLogicDataBeginTurn)0x41e290,
     },
     // Scenario Editor
     Functions{
@@ -572,6 +575,7 @@ static std::array<Functions, 4> functions = {{
         (AddSideshowUnitToUI)nullptr,
         (GetSideshowUnitImpl)nullptr,
         (FindCapitalByPlayerId)nullptr,
+        (MidServerLogicDataBeginTurn)nullptr,
     },
 }};
 

--- a/mss32/src/hooks.cpp
+++ b/mss32/src/hooks.cpp
@@ -132,6 +132,7 @@
 #include "menunewskirmishmultihooks.h"
 #include "menunewskirmishsingle.h"
 #include "menunewskirmishsinglehooks.h"
+#include "turnhooks.h"
 #include "menuphasehooks.h"
 #include "midautodlgimages.h"
 #include "midautodlgimageshooks.h"
@@ -748,6 +749,11 @@ Hooks getHooks()
     auto& fn = gameFunctions();
     auto& orig = getOriginalFunctions();
 
+    
+  
+ // Called when a player's turn begins.Invoked for all players, including neutral factions.
+    hooks.emplace_back(HookInfo{fn.midServerLogicDataBeginTurn, getBeginTurnHooked(),
+                                getBeginTurnOrig()});
     // Register buildings with custom branch category as unit buildings
     hooks.emplace_back(HookInfo{fn.createBuildingType, createBuildingTypeHooked});
     // Support custom building branch category

--- a/mss32/src/turnhooks.cpp
+++ b/mss32/src/turnhooks.cpp
@@ -1,0 +1,97 @@
+/*
+ * turnhooks.cpp
+ */
+
+#include "turnhooks.h"
+
+#include "commandmsg.h"
+#include "game.h"
+#include "gameutils.h"
+#include "midplayer.h"
+#include "phasegame.h"
+#include "playerview.h"
+#include "scripts.h"
+#include "midserverlogic.h"
+
+#include <sol/sol.hpp>
+#include <spdlog/spdlog.h>
+
+namespace hooks {
+
+using BeginTurnFunc = void(__thiscall*)(game::CMidServerLogicData* thisptr,
+                                        game::CMidgardID* playerId);
+
+static BeginTurnFunc beginTurnOrig;
+
+static std::optional<sol::environment> env;
+static std::optional<sol::function> processTurnStart;
+
+void __fastcall beginTurnHooked(game::CMidServerLogicData* thisptr,
+                                int /*%edx*/,
+                                game::CMidgardID* playerId)
+{
+    using namespace game;
+
+    beginTurnOrig(thisptr, playerId);
+
+    if (!thisptr || !playerId) {
+        return;
+    }
+
+    auto objectMap = getServerObjectMap();
+
+    if (!objectMap) {
+        spdlog::error("[TURN] objectMap == nullptr");
+        return;
+    }
+
+    if (!processTurnStart) {
+
+        static const auto path = scriptsFolder() / "turn.lua";
+
+        processTurnStart = getScriptFunction(path, "processTurnStart", env, false, true);
+
+        if (!processTurnStart) {
+
+            spdlog::error("[TURN] failed to load processTurnStart");
+
+            return;
+        }
+    }
+
+    auto playerObj = objectMap->vftable->findScenarioObjectById(objectMap, playerId);
+
+    if (!playerObj) {
+
+        spdlog::error("[TURN] could not find player {}", idToString(playerId));
+
+        return;
+    }
+
+    auto player = static_cast<const CMidPlayer*>(playerObj);
+
+    bindings::PlayerView playerView(player, objectMap);
+
+    try {
+
+        (*processTurnStart)(playerView);
+
+    } catch (const std::exception& e) {
+
+        spdlog::error("[TURN] Lua exception: {}", e.what());
+
+        showErrorMessageBox(fmt::format("Failed to run turn.lua\nReason: {}", e.what()));
+    }
+}
+
+void* getBeginTurnHooked()
+{
+    return (void*)beginTurnHooked;
+}
+
+void** getBeginTurnOrig()
+{
+    return (void**)&beginTurnOrig;
+}
+
+} // namespace hooks


### PR DESCRIPTION
- Added CMidServerLogicDataBeginTurn game function declaration with version-specific addresses for Akella, Russobit and GOG;
- added new turnhooks module and registered begin turn hook;
- added Lua callback support via Scripts/turn.lua;
- added processTurnStart(player) callback executed at the start of each player turn, including neutral factions;
- exposed PlayerView to Lua turn processing;
- added safety checks and Lua exception handling for turn hooks;
- added TRaceTypeCityInformation-related structures and size asserts for future reverse engineering and city tier data access; 
- registered new source/header files in Visual Studio project files