### PR TITLE
Add map template hash validation and configurable strategic hotkeys

### DIFF
--- a/Scripts/settings.lua
+++ b/Scripts/settings.lua
@@ -89,6 +89,26 @@ settings = {
 		"Travelitem",     -- Travel and utility items
 		"Special"         -- Special quest or unique items
 	},
+	
+	-- Configurable hotkeys for the strategic map interface. 
+	-- Defaults: ctrl/shift/alt is false,
+	-- openSelectedObject = "I"	
+	-- quickSave = ctrl + "Q"	
+	hotkeys = {
+
+		openSelectedObject = {  -- inventory from selected stack or city
+			key = "I",
+			ctrl = false,
+			shift = false,
+			alt = false,
+		},
+		
+		quickSave = { -- quickSave, work in multiplayers game for host
+        key = "Q",
+        ctrl = true,
+		},
+
+	},
 
 	-- Multiplies total damage dealt by split damage (DAM_SPLIT) [1 : 6]
 	-- Split damage is introduced by "custom attack damage ratio"

--- a/mss32/include/game.h
+++ b/mss32/include/game.h
@@ -793,6 +793,18 @@ using StratInterfSendSaveGameMsgToServer = void(__thiscall*)(void* thisPtr,
                                                              const char* saveFilename);
 
 /**
+ * Opens interface for currently selected object.
+ * Depending on selected object type opens:
+ * - stack management
+ * - city stack
+ * - village
+ * - capital
+ * - ruin
+ * etc.
+ */
+using StratInterfOpenSelectedObject = void(__thiscall*)(void* thisPtr);
+
+/**
  * Called when a player's turn begins.
  *
  * Executes core begin turn logic inside CMidServerLogicData.
@@ -947,6 +959,7 @@ struct Functions
     FindCapitalByPlayerId findCapitalByPlayerId;
     StratInterfKeyHandler stratInterfKeyHandler;
     StratInterfSendSaveGameMsgToServer sendSaveGameMsgToServer;
+    StratInterfOpenSelectedObject stratInterfOpenSelectedObject;
     MidServerLogicDataBeginTurn midServerLogicDataBeginTurn;
 };
 

--- a/mss32/include/menucustomlobby.h
+++ b/mss32/include/menucustomlobby.h
@@ -174,6 +174,8 @@ protected:
         std::string gameName;
         std::string password;
         std::string gameFilesHash;
+        std::string templateName;
+        std::string templateHash;
         std::string gameVersion;
         std::string scenarioName;
         std::string scenarioDescription;

--- a/mss32/include/netcustomservice.h
+++ b/mss32/include/netcustomservice.h
@@ -101,6 +101,8 @@ public:
     static constexpr char passwordColumnName[] = "Password";
     static constexpr char scenarioNameColumnName[] = "ScenarioName";
     static constexpr char scenarioDescriptionColumnName[] = "ScenarioDescription";
+    static constexpr char templateNameColumnName[] = "TemplateName";
+    static constexpr char templateHashColumnName[] = "TemplateHash";
     // See SLNet::Lobby2Message::ValidatePassword
     static constexpr std::uint32_t passwordMaxLength{50};
 
@@ -122,6 +124,12 @@ public:
               PacketPriority priority) const;
     const std::string& getGameFilesHash();
     std::vector<std::filesystem::path> getGameFilesToHash() const;
+    void setTemplateInfo(const std::string& name);
+
+    const std::string& getTemplateName() const;
+    const std::string& getTemplateHash();
+
+    std::string computeTemplateHash(const std::string& templateName) const;
     UserInfo getUserInfo() const;
     void processPeerMessages() const;
 
@@ -295,6 +303,8 @@ private:
     std::vector<NetPeerCallback*> m_peerCallbacks;
     mutable std::mutex m_peerCallbacksMutex;
     std::string m_gameFilesHash;
+    std::string m_templateName;
+    std::string m_templateHash;
 };
 
 assert_offset(CNetCustomService, vftable, 0);

--- a/mss32/include/quicksavehook.h
+++ b/mss32/include/quicksavehook.h
@@ -18,6 +18,8 @@
  */
 #pragma once
 
+// TODO: If more strategic interface hotkeys are added, rename this file to better reflect its broader purpose.
+
 namespace hooks {
 using KeyHandler = int(__thiscall*)(void* thisPtr, int key, int a3);
 

--- a/mss32/include/settings.h
+++ b/mss32/include/settings.h
@@ -85,6 +85,21 @@ struct Settings
 
     std::vector<std::string> customSortOrder;
 
+    struct Hotkey
+    {
+        std::uint32_t key{'I'};
+
+        bool ctrl{false};
+        bool shift{false};
+        bool alt{false};
+    };
+
+    struct Hotkeys
+    {
+        Hotkey openSelectedObject;
+        Hotkey quickSave;
+    } hotkeys;
+
     struct AdditionalLordIncome
     {   
         struct Gold

--- a/mss32/src/game.cpp
+++ b/mss32/src/game.cpp
@@ -163,6 +163,7 @@ static std::array<Functions, 4> functions = {{
         (FindCapitalByPlayerId)0x5ea751,
         (StratInterfKeyHandler)0x048eda9,
         (StratInterfSendSaveGameMsgToServer)0x048fed7,
+        (StratInterfOpenSelectedObject)0x490c28,
         (MidServerLogicDataBeginTurn)0x41e7a8,
     },
     // Russobit
@@ -303,6 +304,7 @@ static std::array<Functions, 4> functions = {{
         (FindCapitalByPlayerId)0x5ea751,
         (StratInterfKeyHandler)0x048eda9,
         (StratInterfSendSaveGameMsgToServer)0x048fed7,
+        (StratInterfOpenSelectedObject)0x490c28,
         (MidServerLogicDataBeginTurn)0x41e7a8,
     },
     // Gog
@@ -443,6 +445,7 @@ static std::array<Functions, 4> functions = {{
         (FindCapitalByPlayerId)0x5e9450,
         (StratInterfKeyHandler)0x048e8e3,
         (StratInterfSendSaveGameMsgToServer)0x048fa11,
+        (StratInterfOpenSelectedObject)0x49072c,
         (MidServerLogicDataBeginTurn)0x41e290,
     },
     // Scenario Editor
@@ -583,6 +586,7 @@ static std::array<Functions, 4> functions = {{
         (FindCapitalByPlayerId)nullptr,
         (StratInterfKeyHandler)nullptr,
         (StratInterfSendSaveGameMsgToServer)nullptr,
+        (StratInterfOpenSelectedObject)0x490C28,
         (MidServerLogicDataBeginTurn)nullptr,
     },
 }};

--- a/mss32/src/menucustomlobby.cpp
+++ b/mss32/src/menucustomlobby.cpp
@@ -674,6 +674,28 @@ void __fastcall CMenuCustomLobby::joinBtnHandler(CMenuCustomLobby* thisptr, int 
         }
         thisptr->hideWaitDialog();
         showMessageBox(message);
+    } else if (!room->templateHash.empty()) {
+        auto templatePath = templatesFolder() / room->templateName;
+
+        if (!std::filesystem::exists(templatePath)) {
+            thisptr->hideWaitDialog();
+
+            showMessageBox(
+                fmt::format("Required map template was not found:\n{}", room->templateName));
+
+            return;
+        }
+
+        auto localHash = computeHash({templatePath});
+
+        if (localHash != room->templateHash) {
+            thisptr->hideWaitDialog();
+
+            showMessageBox(
+                fmt::format("Map template differs from the host version:\n{}", room->templateName));
+
+            return;
+        }
     } else if (!room->password.empty()) {
         // Store selected room info because the room list can be updated while the dialog is shown
         thisptr->m_joiningRoomId = room->id;
@@ -867,25 +889,58 @@ bool __fastcall CMenuCustomLobby::ansInfoMsgHandler(CMenuCustomLobby* menu,
 CMenuCustomLobby::RoomInfo CMenuCustomLobby::getRoomInfo(SLNet::RoomDescriptor* roomDescriptor)
 {
     std::vector<std::string> clientNames;
+
     const auto& roomMembers = roomDescriptor->roomMemberList;
+
     for (unsigned int i = 0; i < roomMembers.Size(); ++i) {
         const auto& member = roomMembers[i];
+
         if (member.roomMemberMode != RMM_MODERATOR) {
             clientNames.push_back(member.name.C_String());
         }
     }
 
-    // Add 1 to used and total slots because they are not counting room moderator
+    auto gameNameProperty = roomDescriptor->GetProperty(CNetCustomService::gameNameColumnName);
+
+    auto passwordProperty = roomDescriptor->GetProperty(CNetCustomService::passwordColumnName);
+
+    auto filesHashProperty = roomDescriptor->GetProperty(
+        CNetCustomService::gameFilesHashColumnName);
+
+    auto templateNameProperty = roomDescriptor->GetProperty(
+        CNetCustomService::templateNameColumnName);
+
+    auto templateHashProperty = roomDescriptor->GetProperty(
+        CNetCustomService::templateHashColumnName);
+
+    auto gameVersionProperty = roomDescriptor->GetProperty(
+        CNetCustomService::gameVersionColumnName);
+
+    auto scenarioNameProperty = roomDescriptor->GetProperty(
+        CNetCustomService::scenarioNameColumnName);
+
+    auto scenarioDescriptionProperty = roomDescriptor->GetProperty(
+        CNetCustomService::scenarioDescriptionColumnName);
+
     return {roomDescriptor->lobbyRoomId,
             getRoomModerator(roomDescriptor->roomMemberList)->name,
-            roomDescriptor->GetProperty(CNetCustomService::gameNameColumnName)->c,
-            roomDescriptor->GetProperty(CNetCustomService::passwordColumnName)->c,
-            roomDescriptor->GetProperty(CNetCustomService::gameFilesHashColumnName)->c,
-            roomDescriptor->GetProperty(CNetCustomService::gameVersionColumnName)->c,
-            roomDescriptor->GetProperty(CNetCustomService::scenarioNameColumnName)->c,
-            roomDescriptor->GetProperty(CNetCustomService::scenarioDescriptionColumnName)->c,
+
+            gameNameProperty ? gameNameProperty->c : "",
+            passwordProperty ? passwordProperty->c : "",
+            filesHashProperty ? filesHashProperty->c : "",
+
+            templateNameProperty ? templateNameProperty->c : "",
+            templateHashProperty ? templateHashProperty->c : "",
+
+            gameVersionProperty ? gameVersionProperty->c : "",
+            scenarioNameProperty ? scenarioNameProperty->c : "",
+            scenarioDescriptionProperty ? scenarioDescriptionProperty->c : "",
+
             std::move(clientNames),
+
+            // Add 1 to used and total slots because they are not counting room moderator
             (int)roomDescriptor->GetProperty(DefaultRoomColumns::TC_USED_PUBLIC_SLOTS)->i + 1,
+
             (int)roomDescriptor->GetProperty(DefaultRoomColumns::TC_TOTAL_PUBLIC_SLOTS)->i + 1};
 }
 

--- a/mss32/src/menurandomscenario.cpp
+++ b/mss32/src/menurandomscenario.cpp
@@ -35,6 +35,7 @@
 #include "menuphase.h"
 #include "multilayerimg.h"
 #include "nativegameinfo.h"
+#include "netcustomservice.h"
 #include "scenariotemplates.h"
 #include "spinbuttoninterf.h"
 #include "stringarray.h"
@@ -938,6 +939,14 @@ static void __fastcall buttonGenerateHandler(CMenuRandomScenario* thisptr, int /
         sol::state lua;
         rsg::bindLuaApi(lua);
         rsg::readTemplateSettings(templates[selectedIndex].filename, lua);
+
+        auto service = CNetCustomService::get();
+
+        if (service) {
+            spdlog::info("Selected template '{}'", templates[selectedIndex].filename);
+            service->setTemplateInfo(
+                std::filesystem::path(templates[selectedIndex].filename).filename().string());
+        }
         // Create template contents depending on size and races
         rsg::readTemplateContents(thisptr->scenarioTemplate, lua);
 

--- a/mss32/src/netcustomservice.cpp
+++ b/mss32/src/netcustomservice.cpp
@@ -407,6 +407,36 @@ std::vector<CNetCustomService::ChatMessage> CNetCustomService::readChatMessages(
     return result;
 }
 
+void CNetCustomService::setTemplateInfo(const std::string& name)
+{
+    m_templateName = name;
+    m_templateHash.clear();
+}
+
+const std::string& CNetCustomService::getTemplateName() const
+{
+    return m_templateName;
+}
+
+const std::string& CNetCustomService::getTemplateHash()
+{
+    if (m_templateHash.empty() && !m_templateName.empty()) {
+        m_templateHash = computeTemplateHash(m_templateName);
+    }
+
+    return m_templateHash;
+}
+
+std::string CNetCustomService::computeTemplateHash(const std::string& templateName) const
+{
+    auto file = templatesFolder() / templateName;
+
+    if (!std::filesystem::exists(file))
+        return {};
+
+    return computeHash({file});
+}
+
 bool CNetCustomService::createRoom(const char* gameName,
                                    const char* scenarioName,
                                    const char* scenarioDescription,
@@ -450,8 +480,19 @@ bool CNetCustomService::createRoom(const char* gameName,
     auto scenDescColumn{
         properties.AddColumn(scenarioDescriptionColumnName, DataStructures::Table::STRING)};
 
+    auto templateNameColumn{
+        properties.AddColumn(templateNameColumnName, DataStructures::Table::STRING)};
+
+    auto templateHashColumn{
+        properties.AddColumn(templateHashColumnName, DataStructures::Table::STRING)};
+
+    const auto& templateName = getTemplateName();
+    const auto& templateHash = getTemplateHash();
+
     auto row = properties.AddRow(0);
     row->UpdateCell(hashColumn, filesHash.c_str());
+    row->UpdateCell(templateNameColumn, templateName.c_str());
+    row->UpdateCell(templateHashColumn, templateHash.c_str());
     row->UpdateCell(versionColumn, gameVersion.c_str());
     row->UpdateCell(gameNameColumn, gameName);
     row->UpdateCell(passwordColumn, password);

--- a/mss32/src/quicksavehook.cpp
+++ b/mss32/src/quicksavehook.cpp
@@ -18,10 +18,11 @@
  */
 
 #include "quicksavehook.h"
-
+// TODO: If more strategic interface hotkeys are added, rename this file to better reflect its broader purpose.
 #include "game.h"
 
 #include <Windows.h>
+#include <settings.h>
 using namespace game;
 
 namespace hooks {
@@ -31,13 +32,36 @@ KeyHandler originalKeyHandler = nullptr;
 
 constexpr const char* QuickSaveName = "QuickSave";
 
+bool isHotkeyPressed(const Settings::Hotkey& hotkey, int key)
+{
+    if (static_cast<std::uint32_t>(std::toupper(static_cast<unsigned char>(key))) != hotkey.key) {
+        return false;
+    }
+
+    if (hotkey.ctrl != ((GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0))
+        return false;
+
+    if (hotkey.shift != ((GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0))
+        return false;
+
+    if (hotkey.alt != ((GetAsyncKeyState(VK_MENU) & 0x8000) != 0))
+        return false;
+
+    return true;
+}
+
 int __fastcall hookedKeyHandler(void* thisPtr, void*, int key, int a3)
 {
-    if ((key == 'Q' || key == 'q') && (GetAsyncKeyState(VK_CONTROL) & 0x8000)) {
-        auto realThis = reinterpret_cast<char*>(thisPtr) - 4;
+    auto realThis = reinterpret_cast<char*>(thisPtr) - 4;
 
+    if (isHotkeyPressed(userSettings().hotkeys.quickSave, key)) {
         gameFunctions().sendSaveGameMsgToServer(realThis, QuickSaveName);
+        return 1;
+    }
 
+
+    if (isHotkeyPressed(userSettings().hotkeys.openSelectedObject, key)) {
+        gameFunctions().stratInterfOpenSelectedObject(realThis);
         return 1;
     }
 

--- a/mss32/src/settings.cpp
+++ b/mss32/src/settings.cpp
@@ -252,6 +252,164 @@ static void readLobbySettings(const sol::table& table, Settings::Lobby& value)
     }
 }
 
+
+
+static std::uint32_t parseKeyCode(std::string key)
+{
+    std::transform(key.begin(), key.end(), key.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+
+    if (key.empty())
+        return 0;
+
+    if (key.size() == 1)
+        return key[0];
+
+    static const std::unordered_map<std::string, std::uint32_t> keys = {
+        {"TAB", VK_TAB},           {"SPACE", VK_SPACE},     {"ENTER", VK_RETURN},
+        {"RETURN", VK_RETURN},     {"ESC", VK_ESCAPE},      {"ESCAPE", VK_ESCAPE},
+        {"BACKSPACE", VK_BACK},    {"DELETE", VK_DELETE},   {"INSERT", VK_INSERT},
+        {"HOME", VK_HOME},         {"END", VK_END},         {"PAGEUP", VK_PRIOR},
+        {"PAGEDOWN", VK_NEXT},
+
+        {"LEFT", VK_LEFT},         {"RIGHT", VK_RIGHT},     {"UP", VK_UP},
+        {"DOWN", VK_DOWN},
+
+        {"CTRL", VK_CONTROL},      {"SHIFT", VK_SHIFT},     {"ALT", VK_MENU},
+
+        {"NUM0", VK_NUMPAD0},      {"NUM1", VK_NUMPAD1},    {"NUM2", VK_NUMPAD2},
+        {"NUM3", VK_NUMPAD3},      {"NUM4", VK_NUMPAD4},    {"NUM5", VK_NUMPAD5},
+        {"NUM6", VK_NUMPAD6},      {"NUM7", VK_NUMPAD7},    {"NUM8", VK_NUMPAD8},
+        {"NUM9", VK_NUMPAD9},
+
+        {"PLUS", VK_OEM_PLUS},     {"MINUS", VK_OEM_MINUS}, {"COMMA", VK_OEM_COMMA},
+        {"PERIOD", VK_OEM_PERIOD},
+    };
+
+    auto it = keys.find(key);
+    if (it != keys.end())
+        return it->second;
+
+    if (key[0] == 'F') {
+        int number = std::atoi(key.c_str() + 1);
+        if (number >= 1 && number <= 24)
+            return VK_F1 + number - 1;
+    }
+
+    return 0;
+}
+
+static std::string keyCodeToString(std::uint32_t key)
+{
+    if (key >= 'A' && key <= 'Z')
+        return std::string(1, static_cast<char>(key));
+
+    if (key >= '0' && key <= '9')
+        return std::string(1, static_cast<char>(key));
+
+    if (key >= VK_F1 && key <= VK_F24)
+        return "F" + std::to_string(key - VK_F1 + 1);
+
+    switch (key) {
+    case VK_TAB:
+        return "TAB";
+    case VK_SPACE:
+        return "SPACE";
+    case VK_RETURN:
+        return "ENTER";
+    case VK_ESCAPE:
+        return "ESC";
+    case VK_BACK:
+        return "BACKSPACE";
+    case VK_DELETE:
+        return "DELETE";
+    case VK_INSERT:
+        return "INSERT";
+    case VK_HOME:
+        return "HOME";
+    case VK_END:
+        return "END";
+    case VK_PRIOR:
+        return "PAGEUP";
+    case VK_NEXT:
+        return "PAGEDOWN";
+    case VK_LEFT:
+        return "LEFT";
+    case VK_RIGHT:
+        return "RIGHT";
+    case VK_UP:
+        return "UP";
+    case VK_DOWN:
+        return "DOWN";
+
+    case VK_NUMPAD0:
+        return "NUM0";
+    case VK_NUMPAD1:
+        return "NUM1";
+    case VK_NUMPAD2:
+        return "NUM2";
+    case VK_NUMPAD3:
+        return "NUM3";
+    case VK_NUMPAD4:
+        return "NUM4";
+    case VK_NUMPAD5:
+        return "NUM5";
+    case VK_NUMPAD6:
+        return "NUM6";
+    case VK_NUMPAD7:
+        return "NUM7";
+    case VK_NUMPAD8:
+        return "NUM8";
+    case VK_NUMPAD9:
+        return "NUM9";
+
+    case VK_OEM_PLUS:
+        return "PLUS";
+    case VK_OEM_MINUS:
+        return "MINUS";
+    case VK_OEM_COMMA:
+        return "COMMA";
+    case VK_OEM_PERIOD:
+        return "PERIOD";
+    }
+
+    return "";
+}
+
+static void readHotkey(const sol::table& table,
+                       const char* name,
+                       Settings::Hotkey& value,
+                       const Settings::Hotkey& def)
+{
+    auto hotkey = table.get<sol::optional<sol::table>>(name);
+    if (!hotkey.has_value()) {
+        value = def;
+        return;
+    }
+
+    value.key = parseKeyCode(readSetting(hotkey.value(), "key", keyCodeToString(def.key)));
+
+    value.ctrl = readSetting(hotkey.value(), "ctrl", def.ctrl);
+    value.shift = readSetting(hotkey.value(), "shift", def.shift);
+    value.alt = readSetting(hotkey.value(), "alt", def.alt);
+}
+
+static void readHotkeySettings(const sol::table& table, Settings::Hotkeys& value)
+{
+    const auto& def = defaultSettings().hotkeys;
+
+    value = def;
+
+    auto category = table.get<sol::optional<sol::table>>("hotkeys");
+    if (!category.has_value())
+        return;
+
+    readHotkey(category.value(), "openSelectedObject", value.openSelectedObject,
+               def.openSelectedObject);
+
+    readHotkey(category.value(), "quickSave", value.quickSave, def.quickSave);
+}
+
 static void readDebugSettings(const sol::table& table, Settings::Debug& value)
 {
     const auto& def = defaultSettings().debug;
@@ -457,6 +615,7 @@ static void readSettings(const sol::table& table, Settings& settings)
     readAdditionalCityIncomeSettings(table, settings.additionalCityIncome);
     readExtandedBattleSettings(table, settings.extendedBattle);
     readCustomSortSettings(table, settings);
+    readHotkeySettings(table, settings.hotkeys);
 }
 
 static void readDebugMode(Settings& settings)
@@ -564,6 +723,16 @@ const Settings& baseSettings()
         settings.extendedBattle.maxDotDamage = 300;
         settings.extendedBattle.lowerdamageCanAffectHealer = false;
         settings.extendedBattle.boostdamageCanAffectHealer = false;
+
+        settings.hotkeys.openSelectedObject.key = 'I';
+        settings.hotkeys.openSelectedObject.ctrl = false;
+        settings.hotkeys.openSelectedObject.shift = false;
+        settings.hotkeys.openSelectedObject.alt = false;
+
+        settings.hotkeys.quickSave.key = 'Q';
+        settings.hotkeys.quickSave.ctrl = true;
+        settings.hotkeys.quickSave.shift = false;
+        settings.hotkeys.quickSave.alt = false;
 
         initialized = true;
     }


### PR DESCRIPTION
Lobby - Added map template hash validation before joining multiplayer rooms. 
Prevent joining when the local map template differs from the host version.
Added clear error messages for missing or mismatched templates.
Improved join flow by displaying the wait dialog before file hashing starts. 

Strategic Interface - Added configurable hotkey system. 
Added configurable Quick Save hotkey. 
Added configurable 'Open Selected Object' hotkey.
Introduced hotkey parsing and key code conversion utilities. 
Added hotkey configuration to settings.lua.