### PR TITLE
Separate gameplay/user settings and fix lobby room join

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@
     - Add `ZONE_BORDER` image for zones placement preview to `Interf.ff`;
     - Add translated text ids to `TApp.dbf` and into `generator` section of `Scripts/textids.lua`.
   </details>
+
+ - <details>
+    <summary>Allows to customize lobby client and server connection settings;</summary>
+
+    Configure the `lobby` category in [userSettings.lua](Scripts/userSettings.lua).
+
+    Available settings:
+    - Lobby server IP address and port;
+    - Local client port (`0` means automatic port selection by the operating system).
+     </details>
+
 - Increases maximum game turn to 9999;
 - Allows to load and create scenarios with no magic (maximum spell level set to 0);
 - Buildings up to tier 10 are supported in editor and game;
@@ -89,7 +100,7 @@
 - <details>
     <summary>Allows to set a maximum number of items the player is allowed to transfer between campaign scenarios;</summary>
 
-    Specify `carryOverItemsMax` in [settings.lua](Scripts/settings.lua).
+    Specify `carryOverItemsMax` in [userSettings.lua](Scripts/userSettings.lua).
   </details>
 - <details>
     <summary>Allows to add new music tracks for battle and capital cities;</summary>
@@ -115,12 +126,30 @@
 - <details>
     <summary>Allows banners, resources panel and converted land percentage to be displayed by default;</summary>
 
-    Use the following settings in [settings.lua](Scripts/settings.lua):
+    Use the following settings in [userSettings.lua](Scripts/userSettings.lua):
     - `showBanners`
     - `showResources`
     - `showLandConverted`
   </details>
 - <details>
+    <summary>Allows to configure strategic map hotkeys;</summary>
+
+    Configure the `hotkeys` category in [userSettings.lua](Scripts/userSettings.lua).
+
+    Available actions:
+    - `openSelectedObject` — opens inventory for the selected stack or city;
+    - `quickSave` — performs quick save (host only in multiplayer).
+  </details>
+ - <details>
+    <summary>Allows to customize inventory item sort order;</summary>
+
+    Configure `customSortOrder` in [userSettings.lua](Scripts/userSettings.lua).
+
+    Categories are sorted in the exact order specified.
+    Categories omitted from the list use the default internal order and are placed afterwards.
+  </details>
+
+ - <details>
     <summary>Buttons for bulk item transfer: transfer all items, potions, scrolls/wands or valuables between inventories with single click;</summary>
 
     Add buttons with predefined names to `DLG_CITY_STACK`, `DLG_EXCHANGE` or `DLG_PICKUP_DROP` dialogs in `Interf.dlg` file.<br />
@@ -187,11 +216,11 @@
 - <details>
     <summary>Adds missing information to unit encyclopedia;</summary>
 
-    - Enable `detailedUnitDescription` under `unitEncyclopedia` category in [settings.lua](Scripts/settings.lua) to add the following:
+    - Enable `detailedUnitDescription` under `unitEncyclopedia` category in [userSettings.lua](Scripts/userSettings.lua) to add the following:
         - Modifier values for 'HP', 'Immunities' and 'Wards';
         - Custom unit modifiers.
     - Enable or disable `displayBonusHp` and `displayBonusXp` depending on whether you want to display corresponding bonuses or just total values;
-    - Enable `detailedAttackDescription` under `unitEncyclopedia` category in [settings.lua](Scripts/settings.lua) to add the following:
+    - Enable `detailedAttackDescription` under `unitEncyclopedia` category in [userSettings.lua](Scripts/userSettings.lua) to add the following:
         - Damage of secondary attack if its not either poison, blister or frostbite;
         - Power (if applicable) and source (if it matters) of alternative attack;
         - Value of boost/lower damage if its secondary attack;
@@ -262,7 +291,7 @@
             - Capital / village bonus;
             - Rioting village penalty.    
     - (Optional) Adds dynamic upgrade values to unit encyclopedia:
-        - Enable `displayDynamicUpgradeValues` under `unitEncyclopedia` category in [settings.lua](Scripts/settings.lua);
+        - Enable `displayDynamicUpgradeValues` under `unitEncyclopedia` category in [userSettings.lua] (Scripts/userSettings.lua);
         - Enable `detailedUnitDescription` and/or `detailedAttackDescription` to show upgrade values for corresponding stats;
         - The values are only shown for unit types to avoid clutter:
             - While browsing unit buildings in capital;
@@ -313,7 +342,7 @@
 - <details>
     <summary>Allows to display movement cost for each individual step of parties;</summary>
 
-    See `movementCost` category in [settings.lua](Scripts/settings.lua):
+    See `movementCost` category in [userSettings.lua](Scripts/userSettings.lua):
     - Enable `show` to display movement cost;
     - `textColor` can be used to specify a color (RGB) of the text;
     - `outlineColor` can be used to specify a color (RGB) of the text outline.

--- a/Scripts/settings.lua
+++ b/Scripts/settings.lua
@@ -1,30 +1,25 @@
---[[
-Settings for Disciples 2 Rise of the Elves v3.01 mss32 proxy dll
+--[[ Game settings for Disciples 2 Rise of the Elves v3.01 mss32 proxy dll
+
+This file contains gameplay settings that affect game mechanics and balance.
+
+All players in a multiplayer game must use identical game settings.
+This file participates in multiplayer file verification.
 
 Most settings correspond to features. Refer to the documentation for more information:
-https://github.com/VladimirMakeev/D2ModdingToolset#features
+https://github.com/bartonsun/D2ModdingToolset
 
 If you got this file from the GitHub repository, settings have their default values specified.
 If you omit any setting it will have its default value.
-Most settings have their default values correspond to the vanilla game,
-except for quality-of-life like showBanners / showResources and bug fixes like fixEffectiveHpFormula.
---]]
+Most settings have their default values correspond to the vanilla game.
+
+]]--
 
 settings = {
-	-- Show troops banners
-	showBanners = true,
-	-- Show resources panel
-	showResources = true,
-	-- Show percentage of land coverted
-	showLandConverted = false,
 
 	-- Allow scenarios with prebuilt capital cities
 	preserveCapitalBuildings = false,
 	-- Start with pre built temple in capital for warrior lord
 	buildTempleForWarriorLord = false,
-	-- Maximum number of items the player is allowed to transfer
-	-- between campaign scenarios [0 : INT_MAX]
-	carryOverItemsMax = 5,
 
 	-- Maximum unit damage per attack [300 : INT_MAX]
 	unitMaxDamage = 300,
@@ -53,62 +48,6 @@ settings = {
 	criticalHitDamage = 5,
 	-- Percentage chance of critical hit [0 : 100]
 	criticalHitChance = 100,
-	
-	-- Custom item category order used by:
-	-- BTN_SORT_L_CUSTOM
-	-- BTN_SORT_R_CUSTOM
-	--
-	-- Categories are sorted from top to bottom in the exact order listed here.
-	--
-	-- You may specify only the categories you want to prioritize.
-	-- Any categories omitted from this list will use the default internal order
-	-- and will be placed after the custom categories.
-	--
-	-- This section may also be omitted completely.
-	-- In that case, the built-in default sort order will be used.
-	customSortOrder = {
-		"PotionRevive",   -- Resurrection potions
-		"PotionHeal",     -- Healing potions
-
-		"Weapon",         -- Weapons and offensive artifacts
-		"Armor",          -- Armor and defensive artifacts
-
-		"Jewel",          -- Jewels and rings
-		"Banner",         -- Banners and standards
-
-		"PotionBoost",    -- Temporary stat boost potions
-		"PotionPermanent",-- Permanent stat increase potions
-
-		"Scroll",         -- Spell scrolls
-		"Wand",           -- Magic wands
-
-		"Talisman",       -- Talismans
-		"Orb",            -- Orbs
-
-		"Valuable",       -- Valuable trade items
-		"Travelitem",     -- Travel and utility items
-		"Special"         -- Special quest or unique items
-	},
-	
-	-- Configurable hotkeys for the strategic map interface. 
-	-- Defaults:
-	-- openSelectedObject = "I"	 inventory
-	-- quickSave = ctrl + "Q"	
-	hotkeys = {
-
-		openSelectedObject = {  -- inventory from selected stack or city
-			key = "I",
-			ctrl = false,
-			shift = false,
-			alt = false,
-		},
-		
-		quickSave = { -- quickSave, work in multiplayers game for host
-        key = "Q",
-        ctrl = true,
-		},
-
-	},
 
 	-- Multiplies total damage dealt by split damage (DAM_SPLIT) [1 : 6]
 	-- Split damage is introduced by "custom attack damage ratio"
@@ -147,7 +86,7 @@ settings = {
 	-- Round in battle after which paralyze and petrify attacks
 	-- starts missing targets constantly [1 : INT_MAX]
 	disableAllowedRoundMax = 40,
-	
+
 	-- Change accuracy reduction for mage leaders per each additional target
 	mageLeaderAccuracyReduction = 10,
 
@@ -163,27 +102,22 @@ settings = {
 		-- Absolute: accuracy += bonus;
 		-- Percentage: accuracy += accuracy * bonus / 100;
 		absolute = true,
+
 		-- AI accuracy bonus on easy difficulty [-127 : 127]
 		easy = -15,
+
 		-- AI accuracy bonus on average difficulty [-127 : 127]
 		average = 0,
+
 		-- AI accuracy bonus on hard difficulty [-127 : 127]
 		hard = 5,
+
 		-- AI accuracy bonus on very hard difficulty [-127 : 127]
 		veryHard = 10
 	},
 
 	movementCost = {
-		-- Show stacks movement cost
-		show = true,
-		-- Color components are all in range [0 : 255]
-		textColor = {
-			red = 200, green = 200, blue = 200
-		},
-		outlineColor = {
-			red = 0, green = 0, blue = 0
-		},
-		
+
 		-- Movement cost on water tiles
 		water = {
 			-- Default movement cost
@@ -195,17 +129,17 @@ settings = {
 			-- Movement cost for water-only stacks
 			waterOnly = 2,
 		},
-		
+
 		-- Movement cost on forest tiles
 		forest = {
 			-- Default movement cost
 			default = 4,
 			-- Movement cost for stacks with dead leader
 			withDeadLeader = 8,
-			-- Movement cost for stacks with forest movement bonus 
+			-- Movement cost for stacks with forest movement bonus
 			withBonus = 2,
 		},
-		
+
 		-- Movement cost on plain tiles
 		plain = {
 			-- Default movement cost
@@ -217,56 +151,9 @@ settings = {
 		},
 	},
 
-	lobby = {
-		-- Lobby server public IP and port
-		server = {
-			ip = "104.248.139.25",
-			port = 61111,
-		},
-
-		client = {
-			-- Lobby client port (0 means auto-assign by OS)
-			port = 0,
-		},
-	},
-
 	-- If true, switches attacks miss check to a single random value roll
 	-- instead of check against arithmetic mean of two random numbers
 	missChanceSingleRoll = false,
-
-	unitEncyclopedia = {
-		-- Additional display of some stats bonuses, regeneration, xp reward for killing, etc.
-		detailedUnitDescription = true,
-
-		-- Additional display of some stats bonuses, drain, critical hit, custom attack ratios, etc.
-		detailedAttackDescription = true,
-
-		-- Additional display of dynamic upgrade values (only for unit type encyclopedia to avoid clutter)
-		-- Enable detailedUnitDescription and/or detailedAttackDescription to show upgrade values for corresponding stats
-		displayDynamicUpgradeValues = false,
-
-		-- Additional display of bonus hit points
-		-- Requires detailedUnitDescription
-		displayBonusHp = false,
-
-		-- Additional display of experience points reduction
-		-- Requires detailedUnitDescription
-		displayBonusXp = false,
-		
-		-- Display infinite effect indicator along with attack name (alternative to effect duration)
-		-- Requires detailedUnitDescription
-		displayInfiniteAttackIndicator = false,
-
-		-- Display Critical Hit text in Attack section instead of Damage and Power sections
-		-- Requires detailedAttackDescription
-		displayCriticalHitTextInAttackName = false,
-
-		-- Allows to update encyclopedia content on the fly by pressing specified keys.
-		-- Used in combination with isShift/Ctrl/AltKeyPressed from unitEncyclopedia.lua
-		updateOnShiftKeyPress = false,
-		updateOnCtrlKeyPress = false,
-		updateOnAltKeyPress = false,
-	},
 
 	-- Fix effective unit hp computation
 	-- Original formula: (hp * armor / 100) + hp
@@ -289,9 +176,11 @@ settings = {
 		-- Allow unit regeneration modifiers to stack.
 		-- By default, the game picks single highest value, then sums it with lord, terrain and city bonuses.
 		cumulativeUnitRegeneration = false,
+
 		-- Enables 'onModifiersChanged' notification for custom modifier scripts.
 		-- Keep it disabled if you don't need it to improve general performance.
 		notifyModifiersChanged = false,
+
 		-- Validate current HP / XP of units when their group changes (units added, removed, rearranged, etc.)
 		-- to resolve issues with custom HP / XP modifiers, that depend on other units (like auras in MNS mod).
 		-- Keep it disabled if you don't need it to improve general performance.
@@ -301,22 +190,26 @@ settings = {
 	battle = {
 		-- Allows retreated units to upgrade (the behavior is bugged in vanilla causing non-constant and opaque behaviour)
 		allowRetreatedUnitsToUpgrade = false,
+
 		-- Allows to carry extra XP received over unit's upgrade (limited to value required for the next upgrade minus 1)
 		carryXpOverUpgrade = false,
+
 		-- Allows units to receive multiple upgrades per single battle
 		allowMultiUpgrade = false,
+
 		-- Shows message box when error occurs in AI battle action script.
 		-- When disabled, error messages are silently written to error log
 		debugAi = false,
+
 		-- Fallback action for AI controlled units in case of script errors
 		fallbackAction = BattleAction.Defend,
 	},
-	
+
 	alchemistKeepsAttackCount = false,
 	instantBuffRemoval = false,
 	reviveUsesQtyHeal = false,
 	advancedCure = false,
-	
+
 	extendedBattle = {
 		dotDamageCanStack = false,
 		blisterDamageID = "g202aa0001",

--- a/Scripts/userSettings.lua
+++ b/Scripts/userSettings.lua
@@ -1,0 +1,161 @@
+--[[ User settings for Disciples 2 Rise of the Elves v3.01 mss32 proxy dll
+
+This file contains client-side settings that do not affect gameplay balance.
+It is intended for visual, interface and convenience options.
+
+This file is excluded from multiplayer file verification, so players can use
+different user settings while remaining network compatible.
+
+Most settings correspond to features. Refer to the documentation for more information:
+https://github.com/bartonsun/D2ModdingToolset
+
+If you got this file from the GitHub repository, settings have their default values specified.
+If you omit any setting it will have its default value.
+
+
+]]--
+
+settings = {
+
+	-- Show troops banners
+	showBanners = true,
+
+	-- Show resources panel
+	showResources = true,
+
+	-- Show percentage of land coverted
+	showLandConverted = false,
+
+	-- Maximum number of items the player is allowed to transfer
+	-- between campaign scenarios [0 : INT_MAX]
+	carryOverItemsMax = 5,
+
+	-- Custom item category order used by:
+	-- BTN_SORT_L_CUSTOM
+	-- BTN_SORT_R_CUSTOM
+	--
+	-- Categories are sorted from top to bottom in the exact order listed here.
+	--
+	-- You may specify only the categories you want to prioritize.
+	-- Any categories omitted from this list will use the default internal order
+	-- and will be placed after the custom categories.
+	--
+	-- This section may also be omitted completely.
+	-- In that case, the built-in default sort order will be used.
+	customSortOrder = {
+		"PotionRevive",    -- Resurrection potions
+		"PotionHeal",      -- Healing potions
+
+		"Weapon",          -- Weapons and offensive artifacts
+		"Armor",           -- Armor and defensive artifacts
+
+		"Jewel",           -- Jewels and rings
+		"Banner",          -- Banners and standards
+
+		"PotionBoost",     -- Temporary stat boost potions
+		"PotionPermanent", -- Permanent stat increase potions
+
+		"Scroll",          -- Spell scrolls
+		"Wand",            -- Magic wands
+
+		"Talisman",        -- Talismans
+		"Orb",             -- Orbs
+
+		"Valuable",        -- Valuable trade items
+		"Travelitem",      -- Travel and utility items
+		"Special"          -- Special quest or unique items
+	},
+
+	-- Configurable hotkeys for the strategic map interface.
+	-- Defaults:
+	-- openSelectedObject = "I"  inventory
+	-- quickSave = ctrl + "Q"
+	hotkeys = {
+
+		openSelectedObject = { -- inventory from selected stack or city
+			key = "I",
+			ctrl = false,
+			shift = false,
+			alt = false,
+		},
+
+		quickSave = { -- quick save, works in multiplayer game for host
+			key = "Q",
+			ctrl = true,
+			shift = false,
+			alt = false,
+		},
+	},
+
+	-- Strategic map movement cost display settings.
+	movementCost = {
+
+		-- Show stacks movement cost
+		show = true,
+
+		-- Show remaining movement points after an action on the first red flag
+		showMovementAfterAction = true,
+
+		-- Color components are all in range [0 : 255]
+		textColor = {
+			red = 200,
+			green = 200,
+			blue = 200,
+		},
+
+		outlineColor = {
+			red = 0,
+			green = 0,
+			blue = 0,
+		},
+	},
+
+	lobby = {
+
+		-- Lobby server public IP and port
+		server = {
+			ip = "104.248.139.25",
+			port = 61111,
+		},
+
+		client = {
+			-- Lobby client port (0 means auto-assign by OS)
+			port = 0,
+		},
+	},
+
+	unitEncyclopedia = {
+
+		-- Additional display of some stats bonuses, regeneration, xp reward for killing, etc.
+		detailedUnitDescription = true,
+
+		-- Additional display of some stats bonuses, drain, critical hit, custom attack ratios, etc.
+		detailedAttackDescription = true,
+
+		-- Additional display of dynamic upgrade values (only for unit type encyclopedia to avoid clutter)
+		-- Enable detailedUnitDescription and/or detailedAttackDescription to show upgrade values for corresponding stats
+		displayDynamicUpgradeValues = false,
+
+		-- Additional display of bonus hit points
+		-- Requires detailedUnitDescription
+		displayBonusHp = false,
+
+		-- Additional display of experience points reduction
+		-- Requires detailedUnitDescription
+		displayBonusXp = false,
+
+		-- Display infinite effect indicator along with attack name (alternative to effect duration)
+		-- Requires detailedUnitDescription
+		displayInfiniteAttackIndicator = false,
+
+		-- Display Critical Hit text in Attack section instead of Damage and Power sections
+		-- Requires detailedAttackDescription
+		displayCriticalHitTextInAttackName = false,
+
+		-- Allows to update encyclopedia content on the fly by pressing specified keys.
+		-- Used in combination with isShift/Ctrl/AltKeyPressed from unitEncyclopedia.lua
+		updateOnShiftKeyPress = false,
+		updateOnCtrlKeyPress = false,
+		updateOnAltKeyPress = false,
+	},
+}

--- a/mss32/include/bindings/usersettingsview.h
+++ b/mss32/include/bindings/usersettingsview.h
@@ -1,0 +1,16 @@
+#ifndef USERSETTINGSVIEW_H
+#define USERSETTINGSVIEW_H
+
+#include <sol/forward.hpp>
+
+namespace bindings {
+
+class UserSettingsView
+{
+public:
+    static void bind(sol::state& lua);
+};
+
+} // namespace bindings
+
+#endif

--- a/mss32/include/scripts.h
+++ b/mss32/include/scripts.h
@@ -77,6 +77,12 @@ std::optional<sol::protected_function> getProtectedScriptFunction(
     const char* name,
     bool alwaysExists = false);
 
+sol::environment executeUserSettingsScript(const std::string& source,
+                                           sol::protected_function_result& result);
+
+std::optional<sol::environment> executeUserSettingsFile(const std::filesystem::path& path,
+                                                        bool alwaysExists = false);
+
 } // namespace hooks
 
 #endif // SCRIPTS_H

--- a/mss32/include/settings.h
+++ b/mss32/include/settings.h
@@ -31,13 +31,6 @@ enum class BattleAction : int;
 
 namespace hooks {
 
-struct Color
-{
-    std::uint8_t r{};
-    std::uint8_t g{};
-    std::uint8_t b{};
-};
-
 struct Settings
 {
     int unitMaxDamage;
@@ -47,7 +40,6 @@ struct Settings
     int shatterDamageMax;
     int drainAttackHeal;
     int drainOverflowHeal;
-    int carryOverItemsMax;
     std::uint8_t criticalHitDamage;
     std::uint8_t criticalHitChance;
     std::uint8_t mageLeaderAttackPowerReduction;
@@ -64,9 +56,6 @@ struct Settings
         bool absolute;
     } aiAttackPowerBonus;
 
-    bool showBanners;
-    bool showResources;
-    bool showLandConverted;
     bool preserveCapitalBuildings;
     bool buildTempleForWarriorLord;
     bool allowShatterAttackToMiss;
@@ -82,23 +71,6 @@ struct Settings
     bool freeTransformSelfAttack;
     bool freeTransformSelfAttackInfinite;
     bool fixEffectiveHpFormula;
-
-    std::vector<std::string> customSortOrder;
-
-    struct Hotkey
-    {
-        std::uint32_t key{'I'};
-
-        bool ctrl{false};
-        bool shift{false};
-        bool alt{false};
-    };
-
-    struct Hotkeys
-    {
-        Hotkey openSelectedObject;
-        Hotkey quickSave;
-    } hotkeys;
 
     struct AdditionalLordIncome
     {   
@@ -140,20 +112,6 @@ struct Settings
         } mana;
     } additionalCityIncome;
 
-    struct UnitEncyclopedia
-    {
-        bool detailedUnitDescription;
-        bool detailedAttackDescription;
-        bool displayDynamicUpgradeValues;
-        bool displayBonusHp;
-        bool displayBonusXp;
-        bool displayInfiniteAttackIndicator;
-        bool displayCriticalHitTextInAttackName;
-        bool updateOnShiftKeyPress;
-        bool updateOnCtrlKeyPress;
-        bool updateOnAltKeyPress;
-    } unitEncyclopedia;
-
     struct Modifiers
     {
         bool cumulativeUnitRegeneration;
@@ -193,30 +151,7 @@ struct Settings
             int onRoad;
         } plain;
 
-        Color textColor{};
-        Color outlineColor{};
-        bool show{};
-        bool showMovementAfterAction{};
     } movementCost;
-
-
-    struct Lobby
-    {
-        struct Server
-        {
-            std::string ip{"104.248.139.25"};
-            std::uint16_t port{61111};
-        } server;
-
-        struct Client
-        {
-            // 0 means auto-assign by OS
-            std::uint16_t port{0};
-        } client;
-
-        // Stores login information while the game is running, not getting read from settings.lua
-        std::string password;
-    } lobby;
 
     // Do not expose these settings in public 'settings.lua' template so poor souls won't suffer
     // from their own ignorance
@@ -266,10 +201,10 @@ struct Settings
     std::vector<int> longEffectRemoveChances;
 };
 
-const Settings& baseSettings();
-const Settings& defaultSettings();
-const Settings& userSettings();
-Settings::Lobby& lobbySettings();
+const Settings& baseGameSettings();
+const Settings& defaultGameSettings();
+
+const Settings& gameSettings();
 
 } // namespace hooks
 

--- a/mss32/include/usersettings.h
+++ b/mss32/include/usersettings.h
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the modding toolset for Disciples 2.
+ * (https://github.com/VladimirMakeev/D2ModdingToolset)
+ * Copyright (C) 2020 Vladimir Makeev.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef USERSETTINGS_H
+#define USERSETTINGS_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <sol/sol.hpp>
+
+namespace hooks {
+
+struct Color
+{
+    std::uint8_t r{};
+    std::uint8_t g{};
+    std::uint8_t b{};
+};
+
+struct Hotkey
+{
+    std::uint32_t key{'I'};
+
+    bool ctrl{false};
+    bool shift{false};
+    bool alt{false};
+};
+
+struct Hotkeys
+{
+    Hotkey openSelectedObject;
+    Hotkey quickSave;
+};
+
+struct UnitEncyclopedia
+{
+    bool detailedUnitDescription;
+    bool detailedAttackDescription;
+    bool displayDynamicUpgradeValues;
+    bool displayBonusHp;
+    bool displayBonusXp;
+    bool displayInfiniteAttackIndicator;
+    bool displayCriticalHitTextInAttackName;
+    bool updateOnShiftKeyPress;
+    bool updateOnCtrlKeyPress;
+    bool updateOnAltKeyPress;
+};
+
+/**
+ * Controls movement cost display on the strategic map.
+ */
+struct MovementDisplay
+{
+    Color textColor{};
+    Color outlineColor{};
+
+    bool show{};
+    bool showMovementAfterAction{};
+};
+
+struct Lobby
+{
+    struct Server
+    {
+        std::string ip{"104.248.139.25"};
+        std::uint16_t port{61111};
+    } server;
+
+    struct Client
+    {
+        // 0 means auto-assign by OS
+        std::uint16_t port{0};
+    } client;
+
+    // Stores login information while the game is running,
+    // not loaded from userSettings.lua.
+    std::string password;
+};
+
+struct UserSettings
+{
+    bool showBanners;
+    bool showResources;
+    bool showLandConverted;
+
+    int carryOverItemsMax;
+
+    std::vector<std::string> customSortOrder;
+
+    Hotkeys hotkeys;
+
+    UnitEncyclopedia unitEncyclopedia;
+
+    MovementDisplay movementDisplay;
+
+    Lobby lobby;
+};
+
+const UserSettings& baseUserSettings();
+const UserSettings& defaultUserSettings();
+
+const UserSettings& userSettings();
+
+const sol::environment* userSettingsEnvironment();
+
+Lobby& lobbySettings();
+
+} // namespace hooks
+
+#endif // USERSETTINGS_H

--- a/mss32/mss32.vcxproj
+++ b/mss32/mss32.vcxproj
@@ -159,6 +159,7 @@ call ..\buildDetours.bat ..\Detours
     <ClCompile Include="src\bindings\globalitemsview.cpp" />
     <ClCompile Include="src\bindings\globalspellsview.cpp" />
     <ClCompile Include="src\bindings\spellview.cpp" />
+    <ClCompile Include="src\bindings\usersettingsview.cpp" />
     <ClCompile Include="src\stealmerchantiteminterf.cpp" />
     <ClCompile Include="src\stealitemhooks.cpp" />
     <ClCompile Include="src\addstealspellhooks.cpp" />
@@ -644,6 +645,7 @@ call ..\buildDetours.bat ..\Detours
     <ClCompile Include="src\unittypedescriptor.cpp" />
     <ClCompile Include="src\unitutils.cpp" />
     <ClCompile Include="src\untransformeffecthooks.cpp" />
+    <ClCompile Include="src\usersettings.cpp" />
     <ClCompile Include="src\ussoldierimpl.cpp" />
     <ClCompile Include="src\umattackhooks.cpp" />
     <ClCompile Include="src\usstackleader.cpp" />
@@ -708,6 +710,7 @@ call ..\buildDetours.bat ..\Detours
     <ClInclude Include="include\bindings\globalitemsview.h" />
     <ClInclude Include="include\bindings\globalspellsview.h" />
     <ClInclude Include="include\bindings\spellview.h" />
+    <ClInclude Include="include\bindings\usersettingsview.h" />
     <ClInclude Include="include\stealmerchantiteminterf.h" />
     <ClInclude Include="include\stealitemhooks.h" />
     <ClInclude Include="include\addstealspellhooks.h" />
@@ -1386,6 +1389,7 @@ call ..\buildDetours.bat ..\Detours
     <ClInclude Include="include\trainingcampinterf.h" />
     <ClInclude Include="include\turnhooks.h" />
     <ClInclude Include="include\unitsforhirehooks.h" />
+    <ClInclude Include="include\usersettings.h" />
     <ClInclude Include="include\visitorcreatesite.h" />
     <ClInclude Include="include\visitorcreatesitehooks.h" />
     <ClInclude Include="include\wavstore.h" />

--- a/mss32/mss32.vcxproj.filters
+++ b/mss32/mss32.vcxproj.filters
@@ -1600,6 +1600,29 @@
     <ClCompile Include="src\bindings\globalspellsview.cpp">
       <Filter>bindings</Filter>
     </ClCompile>
+    <ClCompile Include="src\stealmerchantiteminterf.cpp" />
+    <ClCompile Include="src\stealitemhooks.cpp" />
+    <ClCompile Include="src\bindings\bagview.cpp" />
+    <ClCompile Include="src\magetowerview.cpp" />
+    <ClCompile Include="src\batattackblistereffect.cpp" />
+    <ClCompile Include="src\batattackfrostbiteeffect.cpp" />
+    <ClCompile Include="src\batattackpoisoneffect.cpp" />
+    <ClCompile Include="src\batattackparalyze.cpp" />
+    <ClCompile Include="src\batattackpetrify.cpp" />
+    <ClCompile Include="src\batattackdamage.cpp" />
+    <ClCompile Include="src\batattackdefend.cpp" />
+    <ClCompile Include="src\mqpointlist.cpp" />
+    <ClCompile Include="src\plandata.cpp" />
+    <ClCompile Include="src\batattackcure.cpp" />
+    <ClCompile Include="src\batattackrevive.cpp" />
+    <ClCompile Include="src\giveattackhooks.cpp" />
+    <ClCompile Include="src\cureattackhooks.cpp" />
+    <ClCompile Include="src\boostdamagehooks.cpp" />
+    <ClCompile Include="src\midtomb.cpp" />
+    <ClCompile Include="src\usersettings.cpp" />
+    <ClCompile Include="src\bindings\usersettingsview.cpp">
+      <Filter>bindings</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\aipriority.h">
@@ -3976,6 +3999,29 @@
       <Filter>bindings</Filter>
     </ClInclude>
     <ClInclude Include="include\bindings\globalitemsview.h">
+      <Filter>bindings</Filter>
+    </ClInclude>
+    <ClInclude Include="include\stealmerchantiteminterf.h" />
+    <ClInclude Include="include\stealitemhooks.h" />
+    <ClInclude Include="include\bindings\bagview.h" />
+    <ClInclude Include="include\magetowerview.h" />
+    <ClInclude Include="include\batattackblistereffect.h" />
+    <ClInclude Include="include\batattackfrostbiteeffect.h" />
+    <ClInclude Include="include\batattackpoisoneffect.h" />
+    <ClInclude Include="include\batattackparalyze.h" />
+    <ClInclude Include="include\batattackpetrify.h" />
+    <ClInclude Include="include\batattackdamage.h" />
+    <ClInclude Include="include\batattackdefend.h" />
+    <ClInclude Include="include\mqpointlist.h" />
+    <ClInclude Include="include\plandata.h" />
+    <ClInclude Include="include\batattackcure.h" />
+    <ClInclude Include="include\batattackrevive.h" />
+    <ClInclude Include="include\giveattackhooks.h" />
+    <ClInclude Include="include\cureattackhooks.h" />
+    <ClInclude Include="include\boostdamagehooks.h" />
+    <ClInclude Include="include\midtomb.h" />
+    <ClInclude Include="include\usersettings.h" />
+    <ClInclude Include="include\bindings\usersettingsview.h">
       <Filter>bindings</Filter>
     </ClInclude>
   </ItemGroup>

--- a/mss32/src/attackdescriptor.cpp
+++ b/mss32/src/attackdescriptor.cpp
@@ -31,6 +31,7 @@
 #include "ummodifier.h"
 #include "unitutils.h"
 #include "usunitimpl.h"
+#include <usersettings.h>
 
 namespace utils {
 
@@ -160,7 +161,7 @@ int computeDamage(int base,
                               ModifierElementTypeFlag::QtyDamage);
 
         if (damageSplit) {
-            result *= hooks::userSettings().splitDamageMultiplier;
+            result *= hooks::gameSettings().splitDamageMultiplier;
         }
     } else if (hooks::isModifiableDamageAttack(classId)) {
         result = computeValue(base, restrictions.attackDamage->min, damageMax, 0, modifiers,
@@ -168,8 +169,8 @@ int computeDamage(int base,
     }
 
     if (classId == AttackClassId::Shatter) {
-        if (result > hooks::userSettings().shatterDamageMax) {
-            result = hooks::userSettings().shatterDamageMax;
+        if (result > hooks::gameSettings().shatterDamageMax) {
+            result = hooks::gameSettings().shatterDamageMax;
         }
     }
 
@@ -284,7 +285,7 @@ AttackDescriptor::AttackDescriptor(game::IEncUnitDescriptor* descriptor,
         const auto& classes = AttackClassCategories::get();
 
         if (!global && data.classId == classes.revive->id
-            && hooks::userSettings().reviveAttacksUsesQtyHeal == 0) {
+            && hooks::gameSettings().reviveAttacksUsesQtyHeal == 0) {
             auto globalAttack = getAttackImpl(descriptor, type);
             data.heal = globalAttack ? globalAttack->vftable->getQtyHeal(globalAttack) : 0;
         } else {
@@ -310,10 +311,10 @@ AttackDescriptor::AttackDescriptor(game::IEncUnitDescriptor* descriptor,
 
     switch (data.classId) {
     case game::AttackClassId::Drain:
-        data.drain += data.damage * userSettings().drainAttackHeal / 100;
+        data.drain += data.damage * gameSettings().drainAttackHeal / 100;
         break;
     case game::AttackClassId::DrainOverflow:
-        data.drain += data.damage * userSettings().drainOverflowHeal / 100;
+        data.drain += data.damage * gameSettings().drainOverflowHeal / 100;
         break;
     }
 }

--- a/mss32/src/battlemsgdatahooks.cpp
+++ b/mss32/src/battlemsgdatahooks.cpp
@@ -28,7 +28,6 @@
 #include "customattacks.h"
 #include "fortification.h"
 #include "gameutils.h"
-#include "groupview.h"
 #include "intset.h"
 #include "midplayer.h"
 #include "midstack.h"
@@ -537,7 +536,7 @@ void __stdcall aiChooseBattleActionHooked(const game::IMidgardObjectMap* objectM
         const auto message{fmt::format("Could not find player that owns unit {:s} in group {:s}",
                                        idToString(unitId), idToString(&allyGroupId))};
 
-        if (userSettings().battle.debugAi) {
+        if (gameSettings().battle.debugAi) {
             showErrorMessageBox(message);
         } else {
             spdlog::error(message);
@@ -554,7 +553,7 @@ void __stdcall aiChooseBattleActionHooked(const game::IMidgardObjectMap* objectM
         const auto message{fmt::format("Could not find battle action script by attitude {:d}",
                                        static_cast<int>(allyPlayer->attitude.id))};
 
-        if (userSettings().battle.debugAi) {
+        if (gameSettings().battle.debugAi) {
             showErrorMessageBox(message);
         } else {
             spdlog::error(message);
@@ -574,7 +573,7 @@ void __stdcall aiChooseBattleActionHooked(const game::IMidgardObjectMap* objectM
         const auto message{
             fmt::format("Could not find 'chooseAction' function. Script '{:s}'", path.string())};
 
-        if (userSettings().battle.debugAi) {
+        if (gameSettings().battle.debugAi) {
             showErrorMessageBox(message);
         } else {
             spdlog::error(message);
@@ -650,7 +649,7 @@ void __stdcall aiChooseBattleActionHooked(const game::IMidgardObjectMap* objectM
         const auto message{
             fmt::format("Failed to run '{:s}' script. Reason: {:s}", path.string(), e.what())};
 
-        if (userSettings().battle.debugAi) {
+        if (gameSettings().battle.debugAi) {
             showErrorMessageBox(message);
         } else {
             spdlog::error(message);
@@ -658,7 +657,7 @@ void __stdcall aiChooseBattleActionHooked(const game::IMidgardObjectMap* objectM
 
         *targetUnitId = *unitId;
         *attackerUnitId = *unitId;
-        *battleAction = userSettings().battle.fallbackAction;
+        *battleAction = gameSettings().battle.fallbackAction;
     }
 }
 

--- a/mss32/src/battleutils.cpp
+++ b/mss32/src/battleutils.cpp
@@ -40,7 +40,7 @@ int adjustUnitXpReceived(const game::BattleMsgData* battleMsgData,
         result = 1;
     }
 
-    if (!userSettings().battle.allowRetreatedUnitsToUpgrade
+    if (!gameSettings().battle.allowRetreatedUnitsToUpgrade
         && battleApi.getUnitStatus(battleMsgData, &unit->id, BattleStatus::Retreated)) {
         auto soldier = fn.castUnitImplToSoldier(unit->unitImpl);
         auto xpNext = soldier->vftable->getXpNext(soldier);

--- a/mss32/src/bindings/battlemsgdataview.cpp
+++ b/mss32/src/bindings/battlemsgdataview.cpp
@@ -651,7 +651,7 @@ bool BattleMsgDataView::setShatteredArmor(const IdView& unitId, int value)
         return false;
     }
 
-    const int maxShatter = hooks::userSettings().shatteredArmorMax;
+    const int maxShatter = hooks::gameSettings().shatteredArmorMax;
 
     info->shatteredArmor = std::clamp(info->shatteredArmor + value, 0, maxShatter);
 
@@ -845,7 +845,7 @@ bool BattleMsgDataView::cure(const IdView& unitId)
     battleApi.setUnitStatus(battleMsgData, &unitId.id, BattleStatus::Petrify, false);
     battleApi.setUnitStatus(battleMsgData, &unitId.id, BattleStatus::DisableLong, false);
 
-    bool settings = hooks::userSettings().advancedCure != hooks::baseSettings().advancedCure;
+    bool settings = hooks::gameSettings().advancedCure != hooks::gameSettings().advancedCure;
     if (settings)
     {
         battleApi.setUnitStatus(battleMsgData, &unitId.id, BattleStatus::LowerDamageLvl1, false);

--- a/mss32/src/bindings/gameview.cpp
+++ b/mss32/src/bindings/gameview.cpp
@@ -37,7 +37,7 @@ void GameView::bind(sol::state& lua)
 
 int GameView::getUnitMaxDamage() const
 {
-    return hooks::userSettings().unitMaxDamage;
+    return hooks::gameSettings().unitMaxDamage;
 }
 
 int GameView::getUnitMinDamage() const
@@ -52,7 +52,7 @@ int GameView::getLeaderAdditionalDamage() const
 
 int GameView::getUnitMaxArmor() const
 {
-    return hooks::userSettings().unitMaxArmor;
+    return hooks::gameSettings().unitMaxArmor;
 }
 
 bool GameView::isEditor() const

--- a/mss32/src/bindings/usersettingsview.cpp
+++ b/mss32/src/bindings/usersettingsview.cpp
@@ -1,0 +1,175 @@
+#include "usersettingsview.h"
+
+#include "usersettings.h"
+
+#include <sol/sol.hpp>
+#include <spdlog/spdlog.h>
+
+namespace bindings {
+
+using namespace hooks;
+
+void UserSettingsView::bind(sol::state& lua)
+{
+    lua.new_usertype<Color>("Color", "r", &Color::r, "g", &Color::g, "b", &Color::b);
+
+    lua.new_usertype<Hotkey>("Hotkey", "key", &Hotkey::key, "ctrl", &Hotkey::ctrl, "shift",
+                             &Hotkey::shift, "alt", &Hotkey::alt);
+
+    lua.new_usertype<Hotkeys>("Hotkeys", "openSelectedObject", &Hotkeys::openSelectedObject,
+                              "quickSave", &Hotkeys::quickSave);
+
+    lua.new_usertype<UnitEncyclopedia>(
+        "UnitEncyclopedia", "detailedUnitDescription", &UnitEncyclopedia::detailedUnitDescription,
+        "detailedAttackDescription", &UnitEncyclopedia::detailedAttackDescription,
+        "displayDynamicUpgradeValues", &UnitEncyclopedia::displayDynamicUpgradeValues,
+        "displayBonusHp", &UnitEncyclopedia::displayBonusHp, "displayBonusXp",
+        &UnitEncyclopedia::displayBonusXp, "displayInfiniteAttackIndicator",
+        &UnitEncyclopedia::displayInfiniteAttackIndicator, "displayCriticalHitTextInAttackName",
+        &UnitEncyclopedia::displayCriticalHitTextInAttackName, "updateOnShiftKeyPress",
+        &UnitEncyclopedia::updateOnShiftKeyPress, "updateOnCtrlKeyPress",
+        &UnitEncyclopedia::updateOnCtrlKeyPress, "updateOnAltKeyPress",
+        &UnitEncyclopedia::updateOnAltKeyPress);
+
+    lua.new_usertype<MovementDisplay>("MovementDisplay", "textColor", &MovementDisplay::textColor,
+                                      "outlineColor", &MovementDisplay::outlineColor, "show",
+                                      &MovementDisplay::show, "showMovementAfterAction",
+                                      &MovementDisplay::showMovementAfterAction);
+
+    lua.new_usertype<Lobby::Server>("LobbyServer", "ip", &Lobby::Server::ip, "port",
+                                    &Lobby::Server::port);
+
+    lua.new_usertype<Lobby::Client>("LobbyClient", "port", &Lobby::Client::port);
+
+    lua.new_usertype<Lobby>("Lobby", "server", &Lobby::server, "client", &Lobby::client);
+
+    lua.new_usertype<UserSettings>(
+        "UserSettings",
+
+        "showBanners", &UserSettings::showBanners, 
+        "showResources", &UserSettings::showResources,
+        "showLandConverted", &UserSettings::showLandConverted,
+        "carryOverItemsMax", &UserSettings::carryOverItemsMax,
+
+        "customSortOrder", &UserSettings::customSortOrder,
+
+        "hotkeys", &UserSettings::hotkeys,
+
+        "unitEncyclopedia", &UserSettings::unitEncyclopedia,
+
+        "movementDisplay", &UserSettings::movementDisplay,
+
+        "lobby", &UserSettings::lobby,
+
+        "hasSection",
+        [](const UserSettings&, const std::string& name) {
+            auto env = userSettingsEnvironment();
+
+            if (!env)
+                return false;
+
+            auto object = (*env)[name];
+            return object.valid() && object.get_type() == sol::type::table;
+        },
+
+        "getSectionNames",
+        [](const UserSettings&) {
+            std::vector<std::string> names;
+
+            auto env = userSettingsEnvironment();
+
+            if (!env)
+                return names;
+
+            for (const auto& kv : *env) {
+
+                sol::object key = kv.first;
+
+                if (key.get_type() == sol::type::string
+                    && kv.second.get_type() == sol::type::table) {
+                    names.push_back(key.as<std::string>());
+                }
+            }
+
+            return names;
+        },
+
+        "getValue",
+        [](const UserSettings&, const std::string& path, sol::this_state ts) -> sol::object {
+            lua_State* L = ts;
+
+            spdlog::info("current lua {:p}", static_cast<void*>(L));
+            const auto* env = userSettingsEnvironment();
+
+            if (!env || path.empty())
+                return sol::make_object(L, sol::nil);
+
+            sol::object current = *env;
+
+            std::string token;
+
+            auto advance = [&](const std::string& part) -> bool {
+                if (part.empty())
+                    return false;
+
+                if (current.get_type() != sol::type::table)
+                    return false;
+
+                sol::table table = current;
+
+                char* end = nullptr;
+                long index = std::strtol(part.c_str(), &end, 10);
+
+                sol::object next;
+
+                if (*end == '\0')
+                    next = table.get<sol::object>(static_cast<int>(index));
+                else
+                    next = table.get<sol::object>(part);
+
+                if (!next.valid() || next == sol::lua_nil)
+                    return false;
+
+                current = std::move(next);
+                return true;
+            };
+
+            for (size_t i = 0; i < path.size();) {
+                token.clear();
+
+                while (i < path.size() && path[i] != '.' && path[i] != '[')
+                    token += path[i++];
+
+                if (!token.empty()) {
+                    if (!advance(token))
+                        return sol::make_object(L, sol::nil);
+                }
+
+                if (i < path.size() && path[i] == '[') {
+                    ++i;
+
+                    token.clear();
+
+                    while (i < path.size() && path[i] != ']')
+                        token += path[i++];
+
+                    if (i >= path.size())
+                        return sol::make_object(L, sol::nil);
+
+                    ++i;
+
+                    if (!advance(token))
+                        return sol::make_object(L, sol::nil);
+                }
+
+                if (i < path.size() && path[i] == '.')
+                    ++i;
+            }
+
+            return current;
+        });
+
+    lua.set_function("getUserSettings", []() -> const UserSettings& { return userSettings(); });
+}
+
+} // namespace bindings

--- a/mss32/src/cureattackhooks.cpp
+++ b/mss32/src/cureattackhooks.cpp
@@ -95,7 +95,7 @@ namespace hooks {
         targetInfo->blisterAppliedRound = 0;
         targetInfo->frostbiteAppliedRound = 0;
     
-        if (userSettings().advancedCure != baseSettings().advancedCure) {
+        if (gameSettings().advancedCure != baseGameSettings().advancedCure) {
             battleApi.setUnitStatus(battleMsgData, targetUnitId, BattleStatus::LowerDamageLvl1, false);
             battleApi.setUnitStatus(battleMsgData, targetUnitId, BattleStatus::LowerDamageLvl2, false);
             battleApi.setUnitStatus(battleMsgData, targetUnitId, BattleStatus::LowerDamageLong, false);

--- a/mss32/src/customattackhooks.cpp
+++ b/mss32/src/customattackhooks.cpp
@@ -275,8 +275,8 @@ game::CAttackImpl* __fastcall attackImplCtorHooked(game::CAttackImpl* thisptr,
         data->critHit = false;
     }
 
-    data->critDamage = userSettings().criticalHitDamage;
-    data->critPower = userSettings().criticalHitChance;
+    data->critDamage = gameSettings().criticalHitDamage;
+    data->critPower = gameSettings().criticalHitChance;
     if (getCustomAttacks().critSettingsEnabled) {
         int critDamage;
         db.readIntWithBoundsCheck(&critDamage, dbTable, critDamageColumnName, 0, 255);

--- a/mss32/src/customattackutils.cpp
+++ b/mss32/src/customattackutils.cpp
@@ -628,7 +628,7 @@ std::vector<double> computeAttackDamageRatio(const CustomAttackData& customData,
 
     if (customData.damageSplit) {
         for (auto& value : result) {
-            value /= totalRatio * userSettings().splitDamageMultiplier;
+            value /= totalRatio * gameSettings().splitDamageMultiplier;
         }
     }
 
@@ -642,7 +642,7 @@ double computeTotalDamageRatio(const game::IAttack* attack, int targetCount)
 
     auto customData = getCustomAttackData(attack);
     if (customData.damageSplit) {
-        return 1.0 * userSettings().splitDamageMultiplier;
+        return 1.0 * gameSettings().splitDamageMultiplier;
     } else if (customData.damageRatio != 100) {
         double ratio = (double)customData.damageRatio / 100;
 

--- a/mss32/src/doppelgangerhooks.cpp
+++ b/mss32/src/doppelgangerhooks.cpp
@@ -133,9 +133,9 @@ bool __fastcall doppelgangerAttackCanPerformHooked(game::CBatAttackDoppelganger*
         return false;
 
     bool ally = isAllyTarget(thisptr, battleMsgData, targetUnitId);
-    if (ally && !userSettings().doppelgangerRespectsAllyImmunity)
+    if (ally && !gameSettings().doppelgangerRespectsAllyImmunity)
         return true;
-    if (!ally && !userSettings().doppelgangerRespectsEnemyImmunity)
+    if (!ally && !gameSettings().doppelgangerRespectsEnemyImmunity)
         return true;
 
     IAttack* attack = fn.getAttackById(objectMap, &thisptr->attackImplUnitId, thisptr->attackNumber,
@@ -164,9 +164,9 @@ bool __fastcall doppelgangerAttackIsImmuneHooked(game::CBatAttackDoppelganger* t
     }
 
     bool ally = isAllyTarget(thisptr, battleMsgData, unitId);
-    if (ally && !userSettings().doppelgangerRespectsAllyImmunity)
+    if (ally && !gameSettings().doppelgangerRespectsAllyImmunity)
         return false;
-    if (!ally && !userSettings().doppelgangerRespectsEnemyImmunity)
+    if (!ally && !gameSettings().doppelgangerRespectsEnemyImmunity)
         return false;
 
     const auto& fn = gameFunctions();

--- a/mss32/src/dotattackhooks.cpp
+++ b/mss32/src/dotattackhooks.cpp
@@ -187,7 +187,8 @@ namespace hooks {
 
         int curDamage = targetInfo->blisterAppliedDamage;
 
-        targetInfo->blisterAppliedDamage = std::clamp(curDamage + damage, 0, userSettings().extendedBattle.maxDotDamage);
+        targetInfo->blisterAppliedDamage = std::clamp(curDamage + damage, 0,
+                                                      gameSettings().extendedBattle.maxDotDamage);
 
         battleApi.setUnitStatus(battleMsgData, targetUnitId, BattleStatus::Blister, true);
 
@@ -232,7 +233,7 @@ namespace hooks {
         int curDamage = targetInfo->frostbiteAppliedDamage;
 
         targetInfo->frostbiteAppliedDamage = std::clamp(curDamage + damage, 0,
-                                                        userSettings().extendedBattle.maxDotDamage);
+                                                        gameSettings().extendedBattle.maxDotDamage);
 
         battleApi.setUnitStatus(battleMsgData, targetUnitId, BattleStatus::Frostbite, true);
 
@@ -278,7 +279,7 @@ namespace hooks {
         int curDamage = targetInfo->poisonAppliedDamage;
 
         targetInfo->poisonAppliedDamage = std::clamp(curDamage + damage, 0,
-                                                     userSettings().extendedBattle.maxDotDamage);
+                                                     gameSettings().extendedBattle.maxDotDamage);
 
         battleApi.setUnitStatus(battleMsgData, targetUnitId, BattleStatus::Poison, true);
 
@@ -311,7 +312,7 @@ namespace hooks {
         CMidUnit* targetUnit = fn.findUnitById(objectMap, targetUnitId);
 
         int damage = std::clamp(targetInfo->blisterAppliedDamage, 0,
-                                userSettings().extendedBattle.maxDotDamage);
+                                gameSettings().extendedBattle.maxDotDamage);
 
         visitorApi.changeUnitHp(targetUnitId, -damage, objectMap, 1);
 
@@ -343,7 +344,7 @@ namespace hooks {
         CMidUnit* targetUnit = fn.findUnitById(objectMap, targetUnitId);
 
         int damage = std::clamp(targetInfo->frostbiteAppliedDamage, 0,
-                                userSettings().extendedBattle.maxDotDamage);
+                                gameSettings().extendedBattle.maxDotDamage);
 
         visitorApi.changeUnitHp(targetUnitId, -damage, objectMap, 1);
 
@@ -375,7 +376,7 @@ namespace hooks {
         CMidUnit* targetUnit = fn.findUnitById(objectMap, targetUnitId);
 
         int damage = std::clamp(targetInfo->poisonAppliedDamage, 0,
-                                userSettings().extendedBattle.maxDotDamage);
+                                gameSettings().extendedBattle.maxDotDamage);
 
         visitorApi.changeUnitHp(targetUnitId, -damage, objectMap, 1);
 
@@ -461,7 +462,7 @@ namespace hooks {
         }
 
         targetInfo->blisterAppliedDamage = std::clamp(damage, 0,
-                                                      userSettings().extendedBattle.maxDotDamage);
+                                                      gameSettings().extendedBattle.maxDotDamage);
         targetInfo->blisterAppliedRound = battleMsgData->currentRound;
 
         BattleAttackUnitInfo info{};
@@ -540,7 +541,7 @@ namespace hooks {
         }
 
         targetInfo->poisonAppliedDamage = std::clamp(damage, 0,
-                                                      userSettings().extendedBattle.maxDotDamage);
+                                                     gameSettings().extendedBattle.maxDotDamage);
         targetInfo->poisonAppliedRound = battleMsgData->currentRound;
 
         BattleAttackUnitInfo info{};
@@ -619,7 +620,7 @@ namespace hooks {
         }
 
         targetInfo->frostbiteAppliedDamage = std::clamp(damage, 0,
-                                                        userSettings().extendedBattle.maxDotDamage);
+                                                        gameSettings().extendedBattle.maxDotDamage);
         targetInfo->frostbiteAppliedRound = battleMsgData->currentRound;
 
         BattleAttackUnitInfo info{};

--- a/mss32/src/drainattackhooks.cpp
+++ b/mss32/src/drainattackhooks.cpp
@@ -222,7 +222,7 @@ void __fastcall drainAttackOnHitHooked(game::CBatAttackDrain* thisptr,
                                        game::BattleAttackInfo** attackInfo)
 {
     drainAttack(objectMap, battleMsgData, thisptr->attack, &thisptr->unitId, unitId, *attackInfo,
-                userSettings().drainAttackHeal);
+                gameSettings().drainAttackHeal);
 }
 
 void __fastcall drainOverflowAttackOnHitHooked(game::CBatAttackDrainOverflow* thisptr,
@@ -238,7 +238,7 @@ void __fastcall drainOverflowAttackOnHitHooked(game::CBatAttackDrainOverflow* th
 
     const auto drainOverflow = drainAttack(objectMap, battleMsgData, thisptr->attack,
                                            &thisptr->unitId, unitId, *attackInfo,
-                                           userSettings().drainOverflowHeal);
+                                           gameSettings().drainOverflowHeal);
     if (!drainOverflow) {
         return;
     }

--- a/mss32/src/drainlevelhooks.cpp
+++ b/mss32/src/drainlevelhooks.cpp
@@ -106,7 +106,7 @@ void __fastcall drainLevelAttackOnHitHooked(game::CBatAttackDrainLevel* thisptr,
         targetLevel = targetSoldier->vftable->getLevel(targetSoldier);
 
     int drainLevel = targetLevel - 1;
-    if (userSettings().leveledDrainLevelAttack) {
+    if (gameSettings().leveledDrainLevelAttack) {
         const CMidUnit* unit = fn.findUnitById(objectMap, &thisptr->unitId);
         drainLevel = getDrainLevel(unit, targetUnit, objectMap, &thisptr->unitOrItemId,
                                    battleMsgData);

--- a/mss32/src/enclayoutunithooks.cpp
+++ b/mss32/src/enclayoutunithooks.cpp
@@ -53,6 +53,7 @@
 #include "unitutils.h"
 #include "usunitimpl.h"
 #include "utils.h"
+#include <usersettings.h>
 
 namespace hooks {
 

--- a/mss32/src/groupupgradehooks.cpp
+++ b/mss32/src/groupupgradehooks.cpp
@@ -74,12 +74,12 @@ int changeUnitXpAndUpgrade(game::IMidgardObjectMap* objectMap,
             break;
         }
 
-        if (!userSettings().battle.allowMultiUpgrade) {
+        if (!gameSettings().battle.allowMultiUpgrade) {
             break;
         }
     }
 
-    if (userSettings().battle.carryXpOverUpgrade) {
+    if (gameSettings().battle.carryXpOverUpgrade) {
         xpAdded += addUnitXpNoUpgrade(objectMap, unit, xpReceived - xpAdded);
     }
 

--- a/mss32/src/hooks.cpp
+++ b/mss32/src/hooks.cpp
@@ -198,6 +198,7 @@
 #include "scenedithooks.h"
 #include "scenpropinterfhooks.h"
 #include "settings.h"
+#include "usersettings.h"
 #include "sitecategoryhooks.h"
 #include "sitemerchantinterf.h"
 #include "sitemerchantinterfhooks.h"
@@ -267,7 +268,7 @@
 #include "dotattackhooks.h"
 #include "batunitanim.h"
 #include <midbag.h>
-#include <miditem.h>
+
 #include <midruin.h>
 #include <midgardplan.h>
 #include "quicksavehook.h"
@@ -585,8 +586,8 @@ static Hooks getGameHooks()
     // clang-format on
     
     // Extended battle options
-    if (userSettings().extendedBattle.dotDamageCanStack
-        != baseSettings().extendedBattle.dotDamageCanStack) {
+    if (gameSettings().extendedBattle.dotDamageCanStack
+        != baseGameSettings().extendedBattle.dotDamageCanStack) {
         hooks.emplace_back(HookInfo{CBatAttackBlisterApi::vftable()->canPerform, blisterCanPerformHooked});
         hooks.emplace_back(HookInfo{CBatAttackBlisterApi::vftable()->onHit, blisterOnHitHooked});
         hooks.emplace_back(HookInfo{CBatAttackFrostbiteApi::vftable()->canPerform, frostbiteCanPerformHooked});
@@ -604,64 +605,64 @@ static Hooks getGameHooks()
         hooks.emplace_back(HookInfo{CBatAttackPoisonApi::vftable()->canPerform, defaultPoisonCanPerformHooked});
     }
 
-    if (userSettings().extendedBattle.boostdamageCanAffectHealer
-        != baseSettings().extendedBattle.boostdamageCanAffectHealer) {
+    if (gameSettings().extendedBattle.boostdamageCanAffectHealer
+        != baseGameSettings().extendedBattle.boostdamageCanAffectHealer) {
         hooks.emplace_back( HookInfo{CBatAttackBoostDamageApi::vftable()->canPerform, boostDamageCanPerformHooked});
         hooks.emplace_back( HookInfo{CBatAttackBoostDamageApi::vftable()->onHit, boostDamageOnHitHooked});
     }
 
-    if (userSettings().extendedBattle.lowerdamageCanAffectHealer
-        != baseSettings().extendedBattle.lowerdamageCanAffectHealer) {
+    if (gameSettings().extendedBattle.lowerdamageCanAffectHealer
+        != baseGameSettings().extendedBattle.lowerdamageCanAffectHealer) {
         hooks.emplace_back( HookInfo{CBatAttackLowerDamageApi::vftable()->canPerform, lowerDamageCanPerformHooked});
     }
     // End extended battle options
 
     // Advanced cure
-    if (userSettings().advancedCure != baseSettings().advancedCure) {
+    if (gameSettings().advancedCure != baseGameSettings().advancedCure) {
         hooks.emplace_back(
             HookInfo{battle.unitCanBeCured, unitCanBeCuredHooked, (void**)&orig.unitCanBeCured});
     }
 
-    if (userSettings().engine.sendRefreshInfoObjectCountLimit) {
+    if (gameSettings().engine.sendRefreshInfoObjectCountLimit) {
         // Fix incomplete scenario loading when its object size exceed network message buffer size
         // of 512 KB
         hooks.emplace_back(HookInfo{CMidServerLogicApi::get().sendRefreshInfo,
                                     midServerLogicSendRefreshInfoHooked});
     }
 
-    if (userSettings().shatteredArmorMax != baseSettings().shatteredArmorMax) {
+    if (gameSettings().shatteredArmorMax != baseGameSettings().shatteredArmorMax) {
         // Allow users to customize total armor shatter damage
         hooks.emplace_back(
             HookInfo{CBatAttackShatterApi::vftable()->canPerform, shatterCanPerformHooked});
         hooks.emplace_back(HookInfo{battle.setUnitShatteredArmor, setUnitShatteredArmorHooked});
     }
 
-    if (userSettings().shatterDamageMax != baseSettings().shatterDamageMax) {
+    if (gameSettings().shatterDamageMax != baseGameSettings().shatterDamageMax) {
         // Allow users to customize maximum armor shatter damage per attack
         hooks.emplace_back(HookInfo{CBatAttackShatterApi::vftable()->onHit, shatterOnHitHooked});
     }
 
-    if (userSettings().showBanners != baseSettings().showBanners) {
+    if (userSettings().showBanners != baseUserSettings().showBanners) {
         // Allow users to show banners by default
         hooks.emplace_back(HookInfo{fn.toggleShowBannersInit, toggleShowBannersInitHooked});
     }
 
-    if (userSettings().showResources != baseSettings().showResources
-        || userSettings().showLandConverted != baseSettings().showLandConverted) {
+    if (userSettings().showResources != baseUserSettings().showResources
+        || userSettings().showLandConverted != baseUserSettings().showLandConverted) {
         // Allow users to show resources panel by default
         hooks.emplace_back(HookInfo{fn.respopupInit, respopupInitHooked});
     }
 
-    if (userSettings().carryOverItemsMax != baseSettings().carryOverItemsMax) {
+    if (userSettings().carryOverItemsMax != baseUserSettings().carryOverItemsMax) {
         // Change maximum number of items that player can carry between campaign scenarios
         hooks.emplace_back(HookInfo{CDDCarryOverItemsApi::get().constructor,
                                     carryOverItemsCtorHooked, (void**)&orig.carryOverItemsCtor});
     }
 
-    if (userSettings().doppelgangerRespectsEnemyImmunity
-            != baseSettings().doppelgangerRespectsEnemyImmunity
-        || userSettings().doppelgangerRespectsAllyImmunity
-               != baseSettings().doppelgangerRespectsAllyImmunity) {
+    if (gameSettings().doppelgangerRespectsEnemyImmunity
+            != baseGameSettings().doppelgangerRespectsEnemyImmunity
+        || gameSettings().doppelgangerRespectsAllyImmunity
+               != baseGameSettings().doppelgangerRespectsAllyImmunity) {
         // Make Doppelganger attack respect target source/class wards and immunities
         hooks.emplace_back(HookInfo{CBatAttackDoppelgangerApi::vftable()->canPerform,
                                     doppelgangerAttackCanPerformHooked});
@@ -669,24 +670,24 @@ static Hooks getGameHooks()
                                     doppelgangerAttackIsImmuneHooked});
     }
 
-    if (userSettings().leveledDoppelgangerAttack != baseSettings().leveledDoppelgangerAttack) {
+    if (gameSettings().leveledDoppelgangerAttack != baseGameSettings().leveledDoppelgangerAttack) {
         // Allow doppelganger to transform into leveled units using script logic
         hooks.emplace_back(
             HookInfo{CBatAttackDoppelgangerApi::vftable()->onHit, doppelgangerAttackOnHitHooked});
     }
 
-    if (userSettings().leveledSummonAttack != baseSettings().leveledSummonAttack) {
+    if (gameSettings().leveledSummonAttack != baseGameSettings().leveledSummonAttack) {
         // Allow summon leveled units using script logic
         hooks.emplace_back(
             HookInfo{CBatAttackSummonApi::vftable()->onHit, summonAttackOnHitHooked});
     }
 
-    if (userSettings().missChanceSingleRoll != baseSettings().missChanceSingleRoll) {
+    if (gameSettings().missChanceSingleRoll != baseGameSettings().missChanceSingleRoll) {
         // Compute attack miss chance using single random value, instead of two
         hooks.emplace_back(HookInfo{fn.attackShouldMiss, attackShouldMissHooked});
     }
 
-    if (userSettings().unrestrictedBestowWards != baseSettings().unrestrictedBestowWards) {
+    if (gameSettings().unrestrictedBestowWards != baseGameSettings().unrestrictedBestowWards) {
         // Increases total ward limit for bestow-wards attack from 8 to 48
         // clang-format off
         hooks.emplace_back(HookInfo{battle.constructor, battleMsgDataCtorHooked, (void**)&orig.battleMsgDataCtor});
@@ -705,26 +706,26 @@ static Hooks getGameHooks()
         // clang-format on
     }
 
-    if (userSettings().movementCost.show) {
+    if (userSettings().movementDisplay.show) {
         // Show movement cost
         hooks.emplace_back(HookInfo{fn.showMovementPath, showMovementPathHooked});
     }
 
     bool hookSendObjectsChanges = false;
-    if (userSettings().debugMode) {
+    if (gameSettings().debugMode) {
         // clang-format off
         // Log all net messages being sent by single player (both client and server) to netMessages<PID>.log
-        if (userSettings().debug.logSinglePlayerMessages) {
+        if (gameSettings().debug.logSinglePlayerMessages) {
             hooks.emplace_back(HookInfo{CNetSinglePlayerApi::vftable()->sendMessage, netSinglePlayerSendMessageHooked, (void**)&orig.netSinglePlayerSendMessage});
         }
         // Log added/changed/erased objects ids being sent by server to netMessages<PID>.log
-        if (userSettings().debug.sendObjectsChangesTreshold) {
+        if (gameSettings().debug.sendObjectsChangesTreshold) {
             hookSendObjectsChanges = true;
         }
         // clang-format on
     }
 
-    if (userSettings().modifiers.validateUnitsOnGroupChanged) {
+    if (gameSettings().modifiers.validateUnitsOnGroupChanged) {
         // Validate current HP / XP of units when their group changes (units added, removed,
         // rearranged, etc.) to resolve issues with custom HP / XP modifiers, that depend on other
         // units (like auras in MNS mod).
@@ -908,20 +909,20 @@ Hooks getHooks()
     hooks.emplace_back(HookInfo{CMidUnitDescriptorApi ::vftable()->isUnitLeader,
                                 midUnitDescriptorIsUnitLeaderHooked});
 
-    if (userSettings().debugMode) {
+    if (gameSettings().debugMode) {
         // Show and log game exceptions information
         hooks.emplace_back(HookInfo{os_exceptionApi::get().throwException, throwExceptionHooked,
                                     (void**)&orig.throwException});
     }
 
-    if (userSettings().shatterDamageUpgradeRatio != baseSettings().shatterDamageUpgradeRatio) {
+    if (gameSettings().shatterDamageUpgradeRatio != baseGameSettings().shatterDamageUpgradeRatio) {
         // Allow users to customize shatter damage upgrade ratio
         hooks.emplace_back(
             HookInfo{fn.applyDynUpgradeToAttackData, applyDynUpgradeToAttackDataHooked});
     }
 
     if (userSettings().unitEncyclopedia.detailedAttackDescription
-        != baseSettings().unitEncyclopedia.detailedAttackDescription) {
+        != baseUserSettings().unitEncyclopedia.detailedAttackDescription) {
         // Additional display of some stats bonuses, drain, critical hit, custom attack ratios, etc.
         hooks.emplace_back(HookInfo{fn.generateAttackDescription, generateAttackDescriptionHooked});
     }
@@ -950,7 +951,7 @@ Hooks getHooks()
     hooks.emplace_back(
         HookInfo{DisplayHandlersApi::get().villageHandler, displayHandlerVillageHooked});
 
-    if (userSettings().modifiers.cumulativeUnitRegeneration) {
+    if (gameSettings().modifiers.cumulativeUnitRegeneration) {
         // Allow unit regeneration modifiers to stack
         hooks.emplace_back(HookInfo{CUmUnitApi::get().constructor, umUnitCtorHooked});
         hooks.emplace_back(HookInfo{CUmUnitApi::get().copyConstructor, umUnitCopyCtorHooked});
@@ -1101,7 +1102,7 @@ Hooks getVftableHooks()
         hooks.emplace_back(HookInfo{&CBatAttackReviveApi::vftable()->isImmune, reviveAttackIsImmuneHooked});
     }
 
-    if (userSettings().allowShatterAttackToMiss != baseSettings().allowShatterAttackToMiss) {
+    if (gameSettings().allowShatterAttackToMiss != baseGameSettings().allowShatterAttackToMiss) {
         if (CBatAttackShatterApi::vftable())
             // Fix an issue where shatter attack always hits regardless of its power value
             hooks.emplace_back(
@@ -1412,7 +1413,7 @@ bool __fastcall shatterCanPerformHooked(game::CBatAttackShatter* thisptr,
     }
 
     const int shatteredArmor = battle.getUnitShatteredArmor(battleMsgData, unitId);
-    if (shatteredArmor >= userSettings().shatteredArmorMax) {
+    if (shatteredArmor >= gameSettings().shatteredArmorMax) {
         return false;
     }
 
@@ -1445,7 +1446,7 @@ void __fastcall setUnitShatteredArmorHooked(game::BattleMsgData* thisptr,
     }
 
     info->shatteredArmor = std::clamp(info->shatteredArmor + armor, 0,
-                                      userSettings().shatteredArmorMax);
+                                      gameSettings().shatteredArmorMax);
 }
 
 void __fastcall shatterOnHitHooked(game::CBatAttackShatter* thisptr,
@@ -1459,7 +1460,7 @@ void __fastcall shatterOnHitHooked(game::CBatAttackShatter* thisptr,
 
     auto attackVftable = (const IAttackVftable*)thisptr->attack->vftable;
 
-    const auto damageMax{userSettings().shatterDamageMax};
+    const auto damageMax{gameSettings().shatterDamageMax};
     int shatterDamage = attackVftable->getQtyDamage(thisptr->attack);
     if (shatterDamage > damageMax) {
         shatterDamage = damageMax;
@@ -1500,7 +1501,7 @@ bool __stdcall buildLordSpecificBuildingsHooked(game::IMidgardObjectMap* objectM
                                                  rtti.CMidPlayerType, 0);
 
     auto& fn = gameFunctions();
-    if (!userSettings().preserveCapitalBuildings) {
+    if (!gameSettings().preserveCapitalBuildings) {
         fn.deletePlayerBuildings(objectMap, player);
     }
 
@@ -1518,7 +1519,8 @@ bool __stdcall buildLordSpecificBuildingsHooked(game::IMidgardObjectMap* objectM
         return fn.addCapitalBuilding(objectMap, player, buildingCategories.magic);
     }
 
-    if (userSettings().buildTempleForWarriorLord && playerInfo->controlledByHuman && lordCategoryId == lordCategories.warrior->id) {
+    if (gameSettings().buildTempleForWarriorLord && playerInfo->controlledByHuman
+        && lordCategoryId == lordCategories.warrior->id) {
         return fn.addCapitalBuilding(objectMap, player, buildingCategories.heal);
     }
 
@@ -1671,7 +1673,7 @@ void __stdcall getAttackPowerHooked(int* power,
         const auto& difficulties = DifficultyLevelCategories::get();
         const auto difficultyId = getScenarioInfo(objectMap)->gameDifficulty.id;
 
-        const auto& aiAttackPower = userSettings().aiAttackPowerBonus;
+        const auto& aiAttackPower = gameSettings().aiAttackPowerBonus;
         const std::int8_t* bonus = &aiAttackPower.easy;
 
         if (difficultyId == difficulties.easy->id) {
@@ -1695,7 +1697,7 @@ void __stdcall getAttackPowerHooked(int* power,
     }
 
     const auto& attacks = AttackClassCategories::get();
-    if (battleMsgData->currentRound > userSettings().disableAllowedRoundMax
+    if (battleMsgData->currentRound > gameSettings().disableAllowedRoundMax
         && (attackClass->id == attacks.paralyze->id || attackClass->id == attacks.petrify->id)) {
         tmpPower = 0;
     }
@@ -1953,7 +1955,7 @@ void __stdcall applyDynUpgradeToAttackDataHooked(const game::CMidgardID* unitImp
     if (attackData->qtyDamage > 0) {
         float ratio = 1.0;
         if (attackData->attackClass->id == AttackClassCategories::get().shatter->id)
-            ratio = (float)userSettings().shatterDamageUpgradeRatio / 100;
+            ratio = (float)gameSettings().shatterDamageUpgradeRatio / 100;
 
         if (upgrade1)
             attackData->qtyDamage += lround(upgrade1->damage * upgrade1Count * ratio);
@@ -2801,7 +2803,7 @@ void __fastcall setUnitStatusHooked(const game::BattleMsgData* battleMsgData,
     switch (bStatus) {
     case BattleStatus::Dead: {
         if (enable) {
-            if (userSettings().instantBuffRemoval != baseSettings().instantBuffRemoval) {
+            if (gameSettings().instantBuffRemoval != baseGameSettings().instantBuffRemoval) {
                 auto* unitInfo = battleApi.getUnitInfoById(battle, unitId);
                 if (unitInfo) {
                     for (const auto& modId : getModifiedUnitIds(unitInfo)) {
@@ -2817,7 +2819,7 @@ void __fastcall setUnitStatusHooked(const game::BattleMsgData* battleMsgData,
         break;
     }
     case BattleStatus::Cured: {
-        if (enable && userSettings().advancedCure != baseSettings().advancedCure) {
+        if (enable && gameSettings().advancedCure != baseGameSettings().advancedCure) {
             battleApi.setUnitStatus(battle, unitId, BattleStatus::LowerDamageLvl1, false);
             battleApi.setUnitStatus(battle, unitId, BattleStatus::LowerDamageLvl2, false);
             battleApi.setUnitStatus(battle, unitId, BattleStatus::LowerDamageLong, false);
@@ -2972,7 +2974,7 @@ void __fastcall reviveAttackOnHitHooked(game::CBatAttackRevive* thisptr,
     static const auto& globalApi = GlobalDataApi::get();
     auto* globalData = *globalApi.getGlobalData();
 
-    const auto& settings = userSettings();
+    const auto& settings = gameSettings();
 
     CMidUnit* targetUnit = fn.findUnitById(objectMap, targetUnitId);
     if (!targetUnit)
@@ -3075,8 +3077,8 @@ bool __stdcall checkLongEffectDurationHooked(int roundsPassed)
     if (roundsPassed == 0)
         return false;
 
-    const auto& chances = userSettings().longEffectRemoveChances;
-    const auto& baseChances = baseSettings().longEffectRemoveChances;
+    const auto& chances = gameSettings().longEffectRemoveChances;
+    const auto& baseChances = baseGameSettings().longEffectRemoveChances;
     const auto& actual = chances.empty() ? baseChances : chances;
 
     int index = roundsPassed - 1;

--- a/mss32/src/interfaceutils.cpp
+++ b/mss32/src/interfaceutils.cpp
@@ -43,6 +43,7 @@
 #include <fmt/format.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <usersettings.h>
 
 namespace hooks {
 

--- a/mss32/src/interftexthooks.cpp
+++ b/mss32/src/interftexthooks.cpp
@@ -36,6 +36,7 @@
 #include "ussoldierimpl.h"
 #include "utils.h"
 #include <fmt/format.h>
+#include <usersettings.h>
 
 namespace hooks {
 
@@ -317,7 +318,7 @@ std::string getDamageDrainAttackDamageText(const utils::AttackDescriptor& actual
                                            int maxTargets,
                                            int damageMax)
 {
-    int multiplier = actual.damageSplit() ? userSettings().splitDamageMultiplier : 1;
+    int multiplier = actual.damageSplit() ? gameSettings().splitDamageMultiplier : 1;
     auto result = getDamageText(actual.damage(), global.damage(), damageMax * multiplier);
 
     if (actual.critHit()) {
@@ -392,11 +393,11 @@ std::string getAttackDamageText(const utils::AttackDescriptor& actual,
     } else if (actual.classId() == classes.heal->id || actual.classId() == classes.bestowWards->id
                || actual.classId() == classes.revive->id) {
         if (actual.classId() == classes.revive->id
-            && userSettings().reviveAttacksUsesQtyHeal == 1) {
+            && gameSettings().reviveAttacksUsesQtyHeal == 1) {
             return getNumberText(0, false);
         }
         bool percent = actual.classId() == classes.revive->id
-                       && userSettings().reviveAttacksUsesQtyHeal == 0;
+                       && gameSettings().reviveAttacksUsesQtyHeal == 0;
         return getModifiedNumberText(actual.heal(), global.heal(), percent);
     } else if (actual.classId() == classes.poison->id || actual.classId() == classes.frostbite->id
                || actual.classId() == classes.blister->id) {
@@ -673,8 +674,8 @@ std::string getSourceField(const utils::AttackDescriptor& actual,
 
     const auto& classes = game::AttackClassCategories::get();
     if (actualAlt.classId() == classes.doppelganger->id) {
-        if (userSettings().doppelgangerRespectsEnemyImmunity
-            || userSettings().doppelgangerRespectsAllyImmunity) {
+        if (gameSettings().doppelgangerRespectsEnemyImmunity
+            || gameSettings().doppelgangerRespectsAllyImmunity) {
             result = addAltAttackText(result, getAttackSourceText(actualAlt, globalAlt));
         }
     }

--- a/mss32/src/itemtransferhooks.cpp
+++ b/mss32/src/itemtransferhooks.cpp
@@ -57,6 +57,7 @@
 #include <spdlog/spdlog.h>
 #include <vector>
 #include <windows.h>
+#include <usersettings.h>
 
 namespace hooks {
 

--- a/mss32/src/main.cpp
+++ b/mss32/src/main.cpp
@@ -97,32 +97,32 @@ static void adjustGameRestrictions()
     // Allow using units with tier higher than 5
     writeProtectedMemory(&restrictions.unitTier->max, 10);
 
-    if (userSettings().unitMaxDamage != baseSettings().unitMaxDamage) {
-        adjustRestrictionMax(restrictions.attackDamage, userSettings().unitMaxDamage,
+    if (gameSettings().unitMaxDamage != baseGameSettings().unitMaxDamage) {
+        adjustRestrictionMax(restrictions.attackDamage, gameSettings().unitMaxDamage,
                              "UnitMaxDamage");
     }
 
-    if (userSettings().unitMaxArmor != baseSettings().unitMaxArmor) {
-        adjustRestrictionMax(restrictions.unitArmor, userSettings().unitMaxArmor, "UnitMaxArmor");
+    if (gameSettings().unitMaxArmor != baseGameSettings().unitMaxArmor) {
+        adjustRestrictionMax(restrictions.unitArmor, gameSettings().unitMaxArmor, "UnitMaxArmor");
     }
 
-    if (userSettings().stackScoutRangeMax != baseSettings().stackScoutRangeMax) {
-        adjustRestrictionMax(restrictions.stackScoutRange, userSettings().stackScoutRangeMax,
+    if (gameSettings().stackScoutRangeMax != baseGameSettings().stackScoutRangeMax) {
+        adjustRestrictionMax(restrictions.stackScoutRange, gameSettings().stackScoutRangeMax,
                              "StackMaxScoutRange");
     }
 
     if (executableIsGame()) {
-        if (userSettings().criticalHitDamage != baseSettings().criticalHitDamage) {
-            spdlog::debug("Set 'criticalHitDamage' to {:d}", (int)userSettings().criticalHitDamage);
-            writeProtectedMemory(restrictions.criticalHitDamage, userSettings().criticalHitDamage);
+        if (gameSettings().criticalHitDamage != baseGameSettings().criticalHitDamage) {
+            spdlog::debug("Set 'criticalHitDamage' to {:d}", (int)gameSettings().criticalHitDamage);
+            writeProtectedMemory(restrictions.criticalHitDamage, gameSettings().criticalHitDamage);
         }
 
-        if (userSettings().mageLeaderAttackPowerReduction
-            != baseSettings().mageLeaderAttackPowerReduction) {
+        if (gameSettings().mageLeaderAttackPowerReduction
+            != baseGameSettings().mageLeaderAttackPowerReduction) {
             spdlog::debug("Set 'mageLeaderPowerReduction' to {:d}",
-                          (int)userSettings().mageLeaderAttackPowerReduction);
+                          (int)gameSettings().mageLeaderAttackPowerReduction);
             writeProtectedMemory(restrictions.mageLeaderAttackPowerReduction,
-                                 userSettings().mageLeaderAttackPowerReduction);
+                                 gameSettings().mageLeaderAttackPowerReduction);
         }
     }
 }
@@ -196,7 +196,7 @@ static void setupDefaultLogger()
     auto fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(fileName.string(),
                                                                            5u << 20, 3);
     // TODO: setting for all available trace levels (not only debug vs non-debug)
-    fileSink->set_level(hooks::userSettings().debugMode ? spdlog::level::trace
+    fileSink->set_level(hooks::gameSettings().debugMode ? spdlog::level::trace
                                                         : spdlog::level::info);
     sinks.push_back(std::move(fileSink));
 

--- a/mss32/src/menucustomlobby.cpp
+++ b/mss32/src/menucustomlobby.cpp
@@ -53,6 +53,21 @@
 
 namespace hooks {
 
+    static DataStructures::Table::Cell* getPropertySafe(SLNet::RoomDescriptor* room, const char* name)
+{
+    auto row = room->roomProperties.GetRowByIndex(0, nullptr);
+    if (!row)
+        return nullptr;
+
+    auto index = room->roomProperties.ColumnIndex(name);
+
+    if (index == (unsigned)-1 || index >= row->cells.Size())
+        return nullptr;
+
+    return room->GetProperty((int)index);
+}
+
+
 CMenuCustomLobby::CMenuCustomLobby(game::CMenuPhase* menuPhase)
     : CMenuCustomBase(this)
     , m_peerCallback(this)
@@ -911,14 +926,13 @@ CMenuCustomLobby::RoomInfo CMenuCustomLobby::getRoomInfo(SLNet::RoomDescriptor* 
 
     auto passwordProperty = roomDescriptor->GetProperty(CNetCustomService::passwordColumnName);
 
-    auto filesHashProperty = roomDescriptor->GetProperty(
-        CNetCustomService::gameFilesHashColumnName);
+    auto filesHashProperty = roomDescriptor->GetProperty(CNetCustomService::gameFilesHashColumnName);
 
-    auto templateNameProperty = roomDescriptor->GetProperty(
-        CNetCustomService::templateNameColumnName);
+    auto templateNameProperty = getPropertySafe(roomDescriptor,
+                                                CNetCustomService::templateNameColumnName);
 
-    auto templateHashProperty = roomDescriptor->GetProperty(
-        CNetCustomService::templateHashColumnName);
+    auto templateHashProperty = getPropertySafe(roomDescriptor,
+                                                CNetCustomService::templateHashColumnName);
 
     auto gameVersionProperty = roomDescriptor->GetProperty(
         CNetCustomService::gameVersionColumnName);

--- a/mss32/src/menucustommain.cpp
+++ b/mss32/src/menucustommain.cpp
@@ -32,6 +32,7 @@
 #include "textboxinterf.h"
 #include "utils.h"
 #include <spdlog/spdlog.h>
+#include <usersettings.h>
 
 namespace hooks {
     

--- a/mss32/src/midserverlogichooks.cpp
+++ b/mss32/src/midserverlogichooks.cpp
@@ -118,7 +118,7 @@ void logObjectsToSend(const game::CMidgardScenarioMap* scenarioMap)
                   addedObjects.length, changedObjects.length, objectsToErase.length);
 
     auto totalLength = addedObjects.length + changedObjects.length + objectsToErase.length;
-    if (totalLength >= userSettings().debug.sendObjectsChangesTreshold) {
+    if (totalLength >= gameSettings().debug.sendObjectsChangesTreshold) {
         for (auto obj : addedObjects) {
             spdlog::debug("Added\t{:s}\t{:s}", idToString(&obj), getMidgardIdTypeDesc(&obj));
         }
@@ -138,11 +138,11 @@ bool __fastcall midServerLogicSendObjectsChangesHooked(game::IMidMsgSender* this
     const auto serverLogic = castMidMsgSenderToMidServerLogic(thisptr);
     auto scenarioMap = CMidServerLogicApi::get().getObjectMap(serverLogic);
 
-    if (userSettings().modifiers.validateUnitsOnGroupChanged) {
+    if (gameSettings().modifiers.validateUnitsOnGroupChanged) {
         addValidatedUnitsToChangedObjects(scenarioMap);
     }
 
-    if (userSettings().debugMode && userSettings().debug.sendObjectsChangesTreshold) {
+    if (gameSettings().debugMode && gameSettings().debug.sendObjectsChangesTreshold) {
         logObjectsToSend(scenarioMap);
     }
 
@@ -159,7 +159,7 @@ bool __fastcall midServerLogicSendRefreshInfoHooked(const game::CMidServerLogic*
     const auto& refreshInfoApi = CRefreshInfoApi::get();
 
     const auto scenarioMap = CMidServerLogicApi::get().getObjectMap(thisptr);
-    const auto limit = userSettings().engine.sendRefreshInfoObjectCountLimit;
+    const auto limit = gameSettings().engine.sendRefreshInfoObjectCountLimit;
 
     auto it = objectsList->begin();
     const auto end = objectsList->end();

--- a/mss32/src/midunithooks.cpp
+++ b/mss32/src/midunithooks.cpp
@@ -109,7 +109,7 @@ bool __fastcall removeModifierHooked(game::CMidUnit* thisptr,
                 prevMod->data->next = next;
             }
 
-            if (userSettings().modifiers.notifyModifiersChanged) {
+            if (gameSettings().modifiers.notifyModifiersChanged) {
                 notifyModifiersChanged(thisptr->unitImpl);
             }
 

--- a/mss32/src/modifierutils.cpp
+++ b/mss32/src/modifierutils.cpp
@@ -395,7 +395,7 @@ game::ModifiedUnitInfo* getModifiedUnits(game::UnitInfo* unitInfo, game::Modifie
     using namespace game;
 
     auto& units = unitInfo->modifiedUnits;
-    if (userSettings().unrestrictedBestowWards) {
+    if (gameSettings().unrestrictedBestowWards) {
         *end = units.patched + ModifiedUnitCountPatched;
         return units.patched;
     } else {
@@ -805,7 +805,7 @@ bool addModifier(game::CMidUnit* unit, const game::CMidgardID* modifierId, bool 
 
     unit->unitImpl = castUmModifierToUnit(modifierImpl);
 
-    if (userSettings().modifiers.notifyModifiersChanged) {
+    if (gameSettings().modifiers.notifyModifiersChanged) {
         notifyModifiersChanged(unit->unitImpl);
     }
 

--- a/mss32/src/movepathhooks.cpp
+++ b/mss32/src/movepathhooks.cpp
@@ -51,6 +51,7 @@
 #include "ruinview.h"
 #include "siteview.h"
 #include <gameutils.h>
+#include <usersettings.h>
 
 namespace hooks {
 
@@ -229,8 +230,8 @@ void __stdcall showMovementPathHooked(const game::IMidgardObjectMap* objectMap,
     CMidgardIDApi::get().fromString(&turnStringId, "X005TA0935");
     const char* turnString{fn.getInterfaceText(&turnStringId)};
 
-    const auto& moveCostColor{userSettings().movementCost.textColor};
-    const auto& moveCostOutline{userSettings().movementCost.outlineColor};
+    const auto& moveCostColor{userSettings().movementDisplay.textColor};
+    const auto& moveCostOutline{userSettings().movementDisplay.outlineColor};
 
     bool firstNode{true};
 
@@ -367,7 +368,7 @@ void __stdcall showMovementPathHooked(const game::IMidgardObjectMap* objectMap,
 
             const bool isActionFlag = endOfPath && pathLeadsToAction;
 
-            if (isActionFlag && userSettings().movementCost.showMovementAfterAction) {
+            if (isActionFlag && userSettings().movementDisplay.showMovementAfterAction) {
 
                 const int spent = node->data.moveCostTotal;
 
@@ -560,7 +561,7 @@ int __stdcall computeMovementCostHooked(const game::CMqPoint* mapPosition,
     const auto& groundTypes = GroundCategories::get();
 
     if (ground.id == groundTypes.water->id) {
-        const auto& water = userSettings().movementCost.water;
+        const auto& water = gameSettings().movementCost.water;
 
         if (!waterOnly) {
             if (leaderAlive) {
@@ -575,7 +576,7 @@ int __stdcall computeMovementCostHooked(const game::CMqPoint* mapPosition,
             return water.waterOnly;
         }
     } else if (ground.id == groundTypes.forest->id) {
-        const auto& forest = userSettings().movementCost.forest;
+        const auto& forest = gameSettings().movementCost.forest;
 
         if (!waterOnly) {
             if (leaderAlive) {
@@ -585,7 +586,7 @@ int __stdcall computeMovementCostHooked(const game::CMqPoint* mapPosition,
             return forest.deadLeader;
         }
     } else if (ground.id == groundTypes.plain->id) {
-        const auto& plain = userSettings().movementCost.plain;
+        const auto& plain = gameSettings().movementCost.plain;
 
         if (!waterOnly) {
             if (!leaderAlive) {

--- a/mss32/src/netcustomservice.cpp
+++ b/mss32/src/netcustomservice.cpp
@@ -33,6 +33,7 @@
 #include <array>
 #include <mutex>
 #include <spdlog/spdlog.h>
+#include <usersettings.h>
 
 namespace hooks {
 
@@ -757,6 +758,10 @@ std::vector<std::filesystem::path> CNetCustomService::getGameFilesToHash() const
                 continue;
             }
 
+            if (entry.path().filename() == "userSettings.lua") {
+                continue;
+            }
+
             result.push_back(entry.path());
         }
     }
@@ -853,7 +858,7 @@ void CNetCustomService::LobbyCallback::MessageResult(
 void CNetCustomService::LobbyCallback::ExecuteDefaultResult(SLNet::Lobby2Message* msg)
 {
     // To optimize out DebugMsg call
-    if (!userSettings().debugMode) {
+    if (!gameSettings().debugMode) {
         return;
     }
 

--- a/mss32/src/playerincomehooks.cpp
+++ b/mss32/src/playerincomehooks.cpp
@@ -108,34 +108,34 @@ game::Bank* __stdcall computePlayerDailyIncomeHooked(game::Bank* income,
     switch (lordId) {
     case LordId::Warrior:
         lordPrefix = "WARRIOR";
-        additionalGoldIncome = userSettings().additionalLordIncome.gold.warrior;
-        additionalManaIncome = userSettings().additionalLordIncome.mana.warrior;
+        additionalGoldIncome = gameSettings().additionalLordIncome.gold.warrior;
+        additionalManaIncome = gameSettings().additionalLordIncome.mana.warrior;
         break;
     case LordId::Mage:
         lordPrefix = "MAGE";
-        additionalGoldIncome = userSettings().additionalLordIncome.gold.mage;
-        additionalManaIncome = userSettings().additionalLordIncome.mana.mage;
+        additionalGoldIncome = gameSettings().additionalLordIncome.gold.mage;
+        additionalManaIncome = gameSettings().additionalLordIncome.mana.mage;
         break;
     case LordId::Diplomat:
         lordPrefix = "GUILDMASTER";
-        additionalGoldIncome = userSettings().additionalLordIncome.gold.guildmaster;
-        additionalManaIncome = userSettings().additionalLordIncome.mana.guildmaster;
+        additionalGoldIncome = gameSettings().additionalLordIncome.gold.guildmaster;
+        additionalManaIncome = gameSettings().additionalLordIncome.mana.guildmaster;
         break;
     }
 
-    std::array<int, 6> cityGoldIncome = {userSettings().additionalCityIncome.gold.capital,
-                                         userSettings().additionalCityIncome.gold.tier1,
-                                         userSettings().additionalCityIncome.gold.tier2,
-                                         userSettings().additionalCityIncome.gold.tier3,
-                                         userSettings().additionalCityIncome.gold.tier4,
-                                         userSettings().additionalCityIncome.gold.tier5};
+    std::array<int, 6> cityGoldIncome = {gameSettings().additionalCityIncome.gold.capital,
+                                         gameSettings().additionalCityIncome.gold.tier1,
+                                         gameSettings().additionalCityIncome.gold.tier2,
+                                         gameSettings().additionalCityIncome.gold.tier3,
+                                         gameSettings().additionalCityIncome.gold.tier4,
+                                         gameSettings().additionalCityIncome.gold.tier5};
 
-    std::array<int, 6> cityManaIncome = {userSettings().additionalCityIncome.mana.capital,
-                                         userSettings().additionalCityIncome.mana.tier1,
-                                         userSettings().additionalCityIncome.mana.tier2,
-                                         userSettings().additionalCityIncome.mana.tier3,
-                                         userSettings().additionalCityIncome.mana.tier4,
-                                         userSettings().additionalCityIncome.mana.tier5};
+    std::array<int, 6> cityManaIncome = {gameSettings().additionalCityIncome.mana.capital,
+                                         gameSettings().additionalCityIncome.mana.tier1,
+                                         gameSettings().additionalCityIncome.mana.tier2,
+                                         gameSettings().additionalCityIncome.mana.tier3,
+                                         gameSettings().additionalCityIncome.mana.tier4,
+                                         gameSettings().additionalCityIncome.mana.tier5};
 
     auto variables{getScenarioVariables(objectMap)};
 

--- a/mss32/src/quicksavehook.cpp
+++ b/mss32/src/quicksavehook.cpp
@@ -23,6 +23,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #include <settings.h>
+#include <usersettings.h>
 using namespace game;
 
 namespace hooks {
@@ -32,7 +33,7 @@ KeyHandler originalKeyHandler = nullptr;
 
 constexpr const char* QuickSaveName = "QuickSave";
 
-bool isHotkeyPressed(const Settings::Hotkey& hotkey, int key)
+bool isHotkeyPressed(const Hotkey& hotkey, int key)
 {
     if (static_cast<std::uint32_t>(std::toupper(static_cast<unsigned char>(key))) != hotkey.key) {
         return false;

--- a/mss32/src/scripts.cpp
+++ b/mss32/src/scripts.cpp
@@ -72,6 +72,7 @@
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/spdlog.h>
 #include <thread>
+#include <usersettingsview.h>
 
 extern std::thread::id mainThreadId;
 
@@ -124,7 +125,7 @@ static std::shared_ptr<spdlog::logger> createLogger(bool client)
                                                 fileName.string(), 5u << 20, 3);
     // TODO: setting for all available trace levels (not only debug vs non-debug)
     // TODO: add log level to the pattern when different log levels are available
-    newLogger->set_level(userSettings().debugMode ? spdlog::level::trace : spdlog::level::info);
+    newLogger->set_level(gameSettings().debugMode ? spdlog::level::trace : spdlog::level::info);
     newLogger->set_pattern("%D %H:%M:%S.%e [%=8!n] %v", spdlog::pattern_time_type::utc);
     return newLogger;
 }
@@ -499,6 +500,7 @@ static void bindApi(sol::state& lua)
     //bindings::ModifierView::bind(lua);
     bindings::BattleTurnView::bind(lua);
     bindings::BattleMsgDataView::bind(lua);
+    bindings::UserSettingsView::bind(lua);
     bindings::BattleMsgDataViewMutable::bind(lua);
     bindings::DiplomacyView::bind(lua);
     bindings::FogView::bind(lua);
@@ -588,6 +590,88 @@ bindings::GlobalView getGlobal()
 bindings::GameView getGame()
 {
     return bindings::GameView();
+}
+
+
+sol::environment executeUserSettingsScript(const std::string& source,
+                                           sol::protected_function_result& result)
+{
+    auto& lua = getLua();
+
+    // Completely isolated environment for user settings.
+    sol::environment env(lua, sol::create);
+
+    // Optional: expose only the standard Lua library if needed.
+    // env["pairs"] = lua["pairs"];
+    // env["ipairs"] = lua["ipairs"];
+    // env["next"] = lua["next"];
+    // env["type"] = lua["type"];
+    // env["math"] = lua["math"];
+    // env["table"] = lua["table"];
+    // env["string"] = lua["string"];
+
+    /*env["io"] = sol::nil;
+    env["os"] = sol::nil;
+    env["package"] = sol::nil;
+    env["require"] = sol::nil;
+    env["load"] = sol::nil;
+    env["loadfile"] = sol::nil;
+    env["dofile"] = sol::nil;
+    env["debug"] = sol::nil;*/
+
+    env["assert"] = lua["assert"];
+    env["error"] = lua["error"];
+
+    env["pairs"] = lua["pairs"];
+    env["ipairs"] = lua["ipairs"];
+    env["next"] = lua["next"];
+
+    env["type"] = lua["type"];
+    env["tostring"] = lua["tostring"];
+    env["tonumber"] = lua["tonumber"];
+    env["select"] = lua["select"];
+
+    env["pcall"] = lua["pcall"];
+    env["xpcall"] = lua["xpcall"];
+
+    env["math"] = lua["math"];
+    env["string"] = lua["string"];
+    env["table"] = lua["table"];
+
+    env["utf8"] = lua["utf8"]; // если Lua 5.3+
+    env["log"] = lua["log"];
+
+    result = lua.safe_script(source, env,
+                             [](lua_State*, sol::protected_function_result pfr) { return pfr; });
+
+    return env;
+}
+
+std::optional<sol::environment> executeUserSettingsFile(const std::filesystem::path& path,
+                                                        bool alwaysExists)
+{
+    if (!alwaysExists && !std::filesystem::exists(path))
+        return std::nullopt;
+
+    const auto& source = getSource(path);
+    if (source.empty()) {
+        showErrorMessageBox(fmt::format("Failed to read '{:s}' script file.", path.string()));
+        return std::nullopt;
+    }
+
+    sol::protected_function_result result;
+
+    auto env = executeUserSettingsScript(source, result);
+
+    if (!result.valid()) {
+        const sol::error err = result;
+        showErrorMessageBox(fmt::format("Failed to execute script '{:s}'.\n"
+                                        "Reason: '{:s}'",
+                                        path.string(), err.what()));
+        return std::nullopt;
+    }
+
+    return {std::move(env)};
 }
 
 sol::environment executeScript(const std::string& source,

--- a/mss32/src/settings.cpp
+++ b/mss32/src/settings.cpp
@@ -46,22 +46,9 @@ static std::string readSetting(const sol::table& table, const char* name, const 
 }
 
 
-static void readCustomSortSettings(const sol::table& table, Settings& settings)
-{
-    settings.customSortOrder.clear();
-
-    auto arr = table.get<sol::optional<sol::table>>("customSortOrder");
-    if (!arr.has_value()) {
-        return;
-    }
-
-    for (auto& kv : arr.value()) {
-        settings.customSortOrder.push_back(kv.second.as<std::string>());
-    }
-}
 static void readAiAttackPowerSettings(const sol::table& table, Settings::AiAttackPowerBonus& value)
 {
-    const auto& def = defaultSettings().aiAttackPowerBonus;
+    const auto& def = defaultGameSettings().aiAttackPowerBonus;
 
     auto bonuses = table.get<sol::optional<sol::table>>("aiAccuracyBonus");
     if (!bonuses.has_value()) {
@@ -78,7 +65,7 @@ static void readAiAttackPowerSettings(const sol::table& table, Settings::AiAttac
 
 static void readAllowBattleItemsSettings(const sol::table& table, Settings::AllowBattleItems& value)
 {
-    const auto& def = defaultSettings().allowBattleItems;
+    const auto& def = defaultGameSettings().allowBattleItems;
 
     auto category = table.get<sol::optional<sol::table>>("allowBattleItems");
     if (!category.has_value()) {
@@ -93,44 +80,9 @@ static void readAllowBattleItemsSettings(const sol::table& table, Settings::Allo
     value.onDoppelganger = readSetting(category.value(), "onDoppelganger", def.onDoppelganger);
 }
 
-static void readUnitEncyclopediaSettings(const sol::table& table, Settings::UnitEncyclopedia& value)
-{
-    const auto& def = defaultSettings().unitEncyclopedia;
-
-    auto category = table.get<sol::optional<sol::table>>("unitEncyclopedia");
-    if (!category.has_value()) {
-        value = def;
-        // For backward compatibility
-        value.detailedAttackDescription = readSetting(table, "detailedAttackDescription",
-                                                      def.detailedAttackDescription);
-        return;
-    }
-
-    value.detailedUnitDescription = readSetting(category.value(), "detailedUnitDescription",
-                                                def.detailedUnitDescription);
-    value.detailedAttackDescription = readSetting(category.value(), "detailedAttackDescription",
-                                                  def.detailedAttackDescription);
-    value.displayDynamicUpgradeValues = readSetting(category.value(), "displayDynamicUpgradeValues",
-                                                    def.displayDynamicUpgradeValues);
-    value.displayBonusHp = readSetting(category.value(), "displayBonusHp", def.displayBonusHp);
-    value.displayBonusXp = readSetting(category.value(), "displayBonusXp", def.displayBonusXp);
-    value.displayInfiniteAttackIndicator = readSetting(category.value(),
-                                                       "displayInfiniteAttackIndicator",
-                                                       def.displayInfiniteAttackIndicator);
-    value.displayCriticalHitTextInAttackName = readSetting(category.value(),
-                                                           "displayCriticalHitTextInAttackName",
-                                                           def.displayCriticalHitTextInAttackName);
-    value.updateOnShiftKeyPress = readSetting(category.value(), "updateOnShiftKeyPress",
-                                              def.updateOnShiftKeyPress);
-    value.updateOnCtrlKeyPress = readSetting(category.value(), "updateOnCtrlKeyPress",
-                                             def.updateOnCtrlKeyPress);
-    value.updateOnAltKeyPress = readSetting(category.value(), "updateOnAltKeyPress",
-                                            def.updateOnAltKeyPress);
-}
-
 static void readModifierSettings(const sol::table& table, Settings::Modifiers& value)
 {
-    const auto& def = defaultSettings().modifiers;
+    const auto& def = defaultGameSettings().modifiers;
 
     auto category = table.get<sol::optional<sol::table>>("modifiers");
     if (!category.has_value()) {
@@ -146,19 +98,10 @@ static void readModifierSettings(const sol::table& table, Settings::Modifiers& v
                                                     def.validateUnitsOnGroupChanged);
 }
 
-static Color readColor(const sol::table& table, const Color& def)
-{
-    Color color{};
-    color.r = readSetting(table, "red", def.r);
-    color.g = readSetting(table, "green", def.g);
-    color.b = readSetting(table, "blue", def.b);
-
-    return color;
-}
 
 static void readWaterMoveCostSettings(const sol::table& table, Settings::MovementCost::Water& water)
 {
-    const auto& def = defaultSettings().movementCost.water;
+    const auto& def = defaultGameSettings().movementCost.water;
 
     water.dflt = readSetting(table, "default", def.dflt, 1);
     water.deadLeader = readSetting(table, "withDeadLeader", def.deadLeader, 1);
@@ -169,7 +112,7 @@ static void readWaterMoveCostSettings(const sol::table& table, Settings::Movemen
 static void readForestMoveCostSettings(const sol::table& table,
                                        Settings::MovementCost::Forest& forest)
 {
-    const auto& def = defaultSettings().movementCost.forest;
+    const auto& def = defaultGameSettings().movementCost.forest;
 
     forest.dflt = readSetting(table, "default", def.dflt, 1);
     forest.deadLeader = readSetting(table, "withDeadLeader", def.deadLeader, 1);
@@ -178,7 +121,7 @@ static void readForestMoveCostSettings(const sol::table& table,
 
 static void readPlainMoveCostSettings(const sol::table& table, Settings::MovementCost::Plain& plain)
 {
-    const auto& def = defaultSettings().movementCost.plain;
+    const auto& def = defaultGameSettings().movementCost.plain;
 
     plain.dflt = readSetting(table, "default", def.dflt, 1);
     plain.deadLeader = readSetting(table, "withDeadLeader", def.deadLeader, 1);
@@ -187,12 +130,6 @@ static void readPlainMoveCostSettings(const sol::table& table, Settings::Movemen
 
 static void readMovementCostSettings(const sol::table& table, Settings::MovementCost& value)
 {
-    const auto& defTextColor = defaultSettings().movementCost.textColor;
-    const auto& defOutlineColor = defaultSettings().movementCost.outlineColor;
-
-    value.show = defaultSettings().movementCost.show;
-    value.textColor = defTextColor;
-    value.outlineColor = defOutlineColor;
 
     auto moveCost = table.get<sol::optional<sol::table>>("movementCost");
     if (!moveCost.has_value()) {
@@ -213,209 +150,12 @@ static void readMovementCostSettings(const sol::table& table, Settings::Movement
     if (plain.has_value()) {
         readPlainMoveCostSettings(plain.value(), value.plain);
     }
-
-    value.show = readSetting(moveCost.value(), "show", defaultSettings().movementCost.show);
-
-    value.showMovementAfterAction = readSetting(moveCost.value(), "showMovementAfterAction",
-                                          defaultSettings().movementCost.showMovementAfterAction);
-
-    auto textColor = moveCost.value().get<sol::optional<sol::table>>("textColor");
-    if (textColor.has_value()) {
-        value.textColor = readColor(textColor.value(), defTextColor);
-    }
-
-    auto outlineColor = moveCost.value().get<sol::optional<sol::table>>("outlineColor");
-    if (outlineColor.has_value()) {
-        value.outlineColor = readColor(outlineColor.value(), defOutlineColor);
-    }
-}
-
-static void readLobbySettings(const sol::table& table, Settings::Lobby& value)
-{
-    const auto& settings = defaultSettings().lobby;
-
-    value.server.ip = settings.server.ip;
-    value.server.port = settings.server.port;
-    value.client.port = settings.client.port;
-
-    auto lobby = table.get<sol::optional<sol::table>>("lobby");
-    if (!lobby.has_value()) {
-        return;
-    }
-
-    auto server = lobby.value().get<sol::optional<sol::table>>("server");
-    if (server.has_value()) {
-        value.server.ip = readSetting(server.value(), "ip", settings.server.ip);
-        value.server.port = readSetting(server.value(), "port", settings.server.port);
-    }
-
-    auto client = lobby.value().get<sol::optional<sol::table>>("client");
-    if (client.has_value()) {
-        value.client.port = readSetting(client.value(), "port", settings.client.port);
-    }
-}
-
-
-
-static std::uint32_t parseKeyCode(std::string key)
-{
-    std::transform(key.begin(), key.end(), key.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
-
-    if (key.empty())
-        return 0;
-
-    if (key.size() == 1)
-        return key[0];
-
-    static const std::unordered_map<std::string, std::uint32_t> keys = {
-        {"TAB", VK_TAB},           {"SPACE", VK_SPACE},     {"ENTER", VK_RETURN},
-        {"RETURN", VK_RETURN},     {"ESC", VK_ESCAPE},      {"ESCAPE", VK_ESCAPE},
-        {"BACKSPACE", VK_BACK},    {"DELETE", VK_DELETE},   {"INSERT", VK_INSERT},
-        {"HOME", VK_HOME},         {"END", VK_END},         {"PAGEUP", VK_PRIOR},
-        {"PAGEDOWN", VK_NEXT},
-
-        {"LEFT", VK_LEFT},         {"RIGHT", VK_RIGHT},     {"UP", VK_UP},
-        {"DOWN", VK_DOWN},
-
-        {"CTRL", VK_CONTROL},      {"SHIFT", VK_SHIFT},     {"ALT", VK_MENU},
-
-        {"NUM0", VK_NUMPAD0},      {"NUM1", VK_NUMPAD1},    {"NUM2", VK_NUMPAD2},
-        {"NUM3", VK_NUMPAD3},      {"NUM4", VK_NUMPAD4},    {"NUM5", VK_NUMPAD5},
-        {"NUM6", VK_NUMPAD6},      {"NUM7", VK_NUMPAD7},    {"NUM8", VK_NUMPAD8},
-        {"NUM9", VK_NUMPAD9},
-
-        {"PLUS", VK_OEM_PLUS},     {"MINUS", VK_OEM_MINUS}, {"COMMA", VK_OEM_COMMA},
-        {"PERIOD", VK_OEM_PERIOD},
-    };
-
-    auto it = keys.find(key);
-    if (it != keys.end())
-        return it->second;
-
-    if (key[0] == 'F') {
-        int number = std::atoi(key.c_str() + 1);
-        if (number >= 1 && number <= 24)
-            return VK_F1 + number - 1;
-    }
-
-    return 0;
-}
-
-static std::string keyCodeToString(std::uint32_t key)
-{
-    if (key >= 'A' && key <= 'Z')
-        return std::string(1, static_cast<char>(key));
-
-    if (key >= '0' && key <= '9')
-        return std::string(1, static_cast<char>(key));
-
-    if (key >= VK_F1 && key <= VK_F24)
-        return "F" + std::to_string(key - VK_F1 + 1);
-
-    switch (key) {
-    case VK_TAB:
-        return "TAB";
-    case VK_SPACE:
-        return "SPACE";
-    case VK_RETURN:
-        return "ENTER";
-    case VK_ESCAPE:
-        return "ESC";
-    case VK_BACK:
-        return "BACKSPACE";
-    case VK_DELETE:
-        return "DELETE";
-    case VK_INSERT:
-        return "INSERT";
-    case VK_HOME:
-        return "HOME";
-    case VK_END:
-        return "END";
-    case VK_PRIOR:
-        return "PAGEUP";
-    case VK_NEXT:
-        return "PAGEDOWN";
-    case VK_LEFT:
-        return "LEFT";
-    case VK_RIGHT:
-        return "RIGHT";
-    case VK_UP:
-        return "UP";
-    case VK_DOWN:
-        return "DOWN";
-
-    case VK_NUMPAD0:
-        return "NUM0";
-    case VK_NUMPAD1:
-        return "NUM1";
-    case VK_NUMPAD2:
-        return "NUM2";
-    case VK_NUMPAD3:
-        return "NUM3";
-    case VK_NUMPAD4:
-        return "NUM4";
-    case VK_NUMPAD5:
-        return "NUM5";
-    case VK_NUMPAD6:
-        return "NUM6";
-    case VK_NUMPAD7:
-        return "NUM7";
-    case VK_NUMPAD8:
-        return "NUM8";
-    case VK_NUMPAD9:
-        return "NUM9";
-
-    case VK_OEM_PLUS:
-        return "PLUS";
-    case VK_OEM_MINUS:
-        return "MINUS";
-    case VK_OEM_COMMA:
-        return "COMMA";
-    case VK_OEM_PERIOD:
-        return "PERIOD";
-    }
-
-    return "";
-}
-
-static void readHotkey(const sol::table& table,
-                       const char* name,
-                       Settings::Hotkey& value,
-                       const Settings::Hotkey& def)
-{
-    auto hotkey = table.get<sol::optional<sol::table>>(name);
-    if (!hotkey.has_value()) {
-        value = def;
-        return;
-    }
-
-    value.key = parseKeyCode(readSetting(hotkey.value(), "key", keyCodeToString(def.key)));
-
-    value.ctrl = readSetting(hotkey.value(), "ctrl", def.ctrl);
-    value.shift = readSetting(hotkey.value(), "shift", def.shift);
-    value.alt = readSetting(hotkey.value(), "alt", def.alt);
-}
-
-static void readHotkeySettings(const sol::table& table, Settings::Hotkeys& value)
-{
-    const auto& def = defaultSettings().hotkeys;
-
-    value = def;
-
-    auto category = table.get<sol::optional<sol::table>>("hotkeys");
-    if (!category.has_value())
-        return;
-
-    readHotkey(category.value(), "openSelectedObject", value.openSelectedObject,
-               def.openSelectedObject);
-
-    readHotkey(category.value(), "quickSave", value.quickSave, def.quickSave);
+  
 }
 
 static void readDebugSettings(const sol::table& table, Settings::Debug& value)
 {
-    const auto& def = defaultSettings().debug;
+    const auto& def = defaultGameSettings().debug;
 
     // 'debug' is reserved to Lua standard debug library
     auto category = table.get<sol::optional<sol::table>>("debugging");
@@ -432,7 +172,7 @@ static void readDebugSettings(const sol::table& table, Settings::Debug& value)
 
 static void readEngineSettings(const sol::table& table, Settings::Engine& value)
 {
-    const auto& def = defaultSettings().engine;
+    const auto& def = defaultGameSettings().engine;
 
     auto category = table.get<sol::optional<sol::table>>("engine");
     if (!category.has_value()) {
@@ -447,7 +187,7 @@ static void readEngineSettings(const sol::table& table, Settings::Engine& value)
 
 static void readBattleSettings(const sol::table& table, Settings::Battle& value)
 {
-    const auto& def = defaultSettings().battle;
+    const auto& def = defaultGameSettings().battle;
 
     auto category = table.get<sol::optional<sol::table>>("battle");
     if (!category.has_value()) {
@@ -470,7 +210,7 @@ static void readBattleSettings(const sol::table& table, Settings::Battle& value)
 static void readAdditionalLordIncomeSettings(const sol::table& table,
                                              Settings::AdditionalLordIncome& value)
 {
-    const auto& def = defaultSettings().additionalLordIncome;
+    const auto& def = defaultGameSettings().additionalLordIncome;
 
     auto income = table.get<sol::optional<sol::table>>("additionalLordIncome");
     if (!income.has_value()) {
@@ -503,7 +243,7 @@ static void readAdditionalLordIncomeSettings(const sol::table& table,
 static void readAdditionalCityIncomeSettings(const sol::table& table,
                                              Settings::AdditionalCityIncome& value)
 {
-    const auto& def = defaultSettings().additionalCityIncome;
+    const auto& def = defaultGameSettings().additionalCityIncome;
 
     auto income = table.get<sol::optional<sol::table>>("additionalCityIncome");
     if (!income.has_value()) {
@@ -540,7 +280,7 @@ static void readAdditionalCityIncomeSettings(const sol::table& table,
 
 static void readExtandedBattleSettings(const sol::table& table, Settings::ExtendedBattle& value)
 {
-    const auto& def = defaultSettings().extendedBattle;
+    const auto& def = defaultGameSettings().extendedBattle;
 
     auto category = table.get<sol::optional<sol::table>>("extendedBattle");
     if (!category.has_value()) {
@@ -565,43 +305,39 @@ static void readExtandedBattleSettings(const sol::table& table, Settings::Extend
 static void readSettings(const sol::table& table, Settings& settings)
 {
     // clang-format off
-    settings.unitMaxDamage = readSetting(table, "unitMaxDamage", defaultSettings().unitMaxDamage);
-    settings.unitMaxArmor = readSetting(table, "unitMaxArmor", defaultSettings().unitMaxArmor);
-    settings.stackScoutRangeMax = readSetting(table, "stackMaxScoutRange", defaultSettings().stackScoutRangeMax);
-    settings.shatteredArmorMax = readSetting(table, "shatteredArmorMax", defaultSettings().shatteredArmorMax, 0, baseSettings().shatteredArmorMax);
-    settings.shatterDamageMax = readSetting(table, "shatterDamageMax", defaultSettings().shatterDamageMax, 0, baseSettings().shatterDamageMax);
-    settings.drainAttackHeal = readSetting(table, "drainAttackHeal", defaultSettings().drainAttackHeal);
-    settings.drainOverflowHeal = readSetting(table, "drainOverflowHeal", defaultSettings().drainOverflowHeal);
-    settings.carryOverItemsMax = readSetting(table, "carryOverItemsMax", defaultSettings().carryOverItemsMax, 0);
-    settings.criticalHitDamage = readSetting(table, "criticalHitDamage", defaultSettings().criticalHitDamage);
-    settings.criticalHitChance = readSetting(table, "criticalHitChance", defaultSettings().criticalHitChance, (uint8_t)0, (uint8_t)100);
-    settings.mageLeaderAttackPowerReduction = readSetting(table, "mageLeaderAccuracyReduction", defaultSettings().mageLeaderAttackPowerReduction);
-    settings.disableAllowedRoundMax = readSetting(table, "disableAllowedRoundMax", defaultSettings().disableAllowedRoundMax, (uint8_t)1);
-    settings.shatterDamageUpgradeRatio = readSetting(table, "shatterDamageUpgradeRatio", defaultSettings().shatterDamageUpgradeRatio);
-    settings.splitDamageMultiplier = readSetting(table, "splitDamageMultiplier", defaultSettings().splitDamageMultiplier, (uint8_t)1, (uint8_t)6);
-    settings.showBanners = readSetting(table, "showBanners", defaultSettings().showBanners);
-    settings.showResources = readSetting(table, "showResources", defaultSettings().showResources);
-    settings.showLandConverted = readSetting(table, "showLandConverted", defaultSettings().showLandConverted);
-    settings.preserveCapitalBuildings = readSetting(table, "preserveCapitalBuildings", defaultSettings().preserveCapitalBuildings);
-    settings.buildTempleForWarriorLord = readSetting(table, "buildTempleForWarriorLord", defaultSettings().buildTempleForWarriorLord);
-    settings.allowShatterAttackToMiss = readSetting(table, "allowShatterAttackToMiss", defaultSettings().allowShatterAttackToMiss);
-    settings.doppelgangerRespectsEnemyImmunity = readSetting(table, "doppelgangerRespectsEnemyImmunity", defaultSettings().doppelgangerRespectsEnemyImmunity);
-    settings.doppelgangerRespectsAllyImmunity = readSetting(table, "doppelgangerRespectsAllyImmunity", defaultSettings().doppelgangerRespectsAllyImmunity);
-    settings.leveledDoppelgangerAttack = readSetting(table, "leveledDoppelgangerAttack", defaultSettings().leveledDoppelgangerAttack);
-    settings.leveledTransformSelfAttack = readSetting(table, "leveledTransformSelfAttack", defaultSettings().leveledTransformSelfAttack);
-    settings.leveledTransformOtherAttack = readSetting(table, "leveledTransformOtherAttack", defaultSettings().leveledTransformOtherAttack);
-    settings.leveledDrainLevelAttack = readSetting(table, "leveledDrainLevelAttack", defaultSettings().leveledDrainLevelAttack);
-    settings.leveledSummonAttack = readSetting(table, "leveledSummonAttack", defaultSettings().leveledSummonAttack);
-    settings.missChanceSingleRoll = readSetting(table, "missChanceSingleRoll", defaultSettings().missChanceSingleRoll);
-    settings.unrestrictedBestowWards = readSetting(table, "unrestrictedBestowWards", defaultSettings().unrestrictedBestowWards);
-    settings.freeTransformSelfAttack = readSetting(table, "freeTransformSelfAttack", defaultSettings().freeTransformSelfAttack);
-    settings.freeTransformSelfAttackInfinite = readSetting(table, "freeTransformSelfAttackInfinite", defaultSettings().freeTransformSelfAttackInfinite);
-    settings.fixEffectiveHpFormula = readSetting(table, "fixEffectiveHpFormula", defaultSettings().fixEffectiveHpFormula);
-    settings.alchemistKeepsAttackCount = readSetting(table, "alchemistKeepsAttackCount", defaultSettings().alchemistKeepsAttackCount);
-    settings.instantBuffRemoval = readSetting(table, "instantBuffRemoval", defaultSettings().instantBuffRemoval);
-    settings.reviveAttacksUsesQtyHeal = readSetting(table, "reviveAttacksUsesQtyHeal", defaultSettings().reviveAttacksUsesQtyHeal);
-    settings.reviveItemsUsesQtyHeal = readSetting(table, "reviveItemsUsesQtyHeal", defaultSettings().reviveItemsUsesQtyHeal);
-    settings.advancedCure = readSetting(table, "advancedCure", defaultSettings().advancedCure);
+    settings.unitMaxDamage = readSetting(table, "unitMaxDamage", defaultGameSettings().unitMaxDamage);
+    settings.unitMaxArmor = readSetting(table, "unitMaxArmor", defaultGameSettings().unitMaxArmor);
+    settings.stackScoutRangeMax = readSetting(table, "stackMaxScoutRange", defaultGameSettings().stackScoutRangeMax);
+    settings.shatteredArmorMax = readSetting(table, "shatteredArmorMax", defaultGameSettings().shatteredArmorMax, 0, baseGameSettings().shatteredArmorMax);
+    settings.shatterDamageMax = readSetting(table, "shatterDamageMax", defaultGameSettings().shatterDamageMax, 0, baseGameSettings().shatterDamageMax);
+    settings.drainAttackHeal = readSetting(table, "drainAttackHeal", defaultGameSettings().drainAttackHeal);
+    settings.drainOverflowHeal = readSetting(table, "drainOverflowHeal", defaultGameSettings().drainOverflowHeal);
+    settings.criticalHitDamage = readSetting(table, "criticalHitDamage", defaultGameSettings().criticalHitDamage);
+    settings.criticalHitChance = readSetting(table, "criticalHitChance", defaultGameSettings().criticalHitChance, (uint8_t)0, (uint8_t)100);
+    settings.mageLeaderAttackPowerReduction = readSetting(table, "mageLeaderAccuracyReduction", defaultGameSettings().mageLeaderAttackPowerReduction);
+    settings.disableAllowedRoundMax = readSetting(table, "disableAllowedRoundMax", defaultGameSettings().disableAllowedRoundMax, (uint8_t)1);
+    settings.shatterDamageUpgradeRatio = readSetting(table, "shatterDamageUpgradeRatio", defaultGameSettings().shatterDamageUpgradeRatio);
+    settings.splitDamageMultiplier = readSetting(table, "splitDamageMultiplier", defaultGameSettings().splitDamageMultiplier, (uint8_t)1, (uint8_t)6);
+    settings.preserveCapitalBuildings = readSetting(table, "preserveCapitalBuildings", defaultGameSettings().preserveCapitalBuildings);
+    settings.buildTempleForWarriorLord = readSetting(table, "buildTempleForWarriorLord", defaultGameSettings().buildTempleForWarriorLord);
+    settings.allowShatterAttackToMiss = readSetting(table, "allowShatterAttackToMiss", defaultGameSettings().allowShatterAttackToMiss);
+    settings.doppelgangerRespectsEnemyImmunity = readSetting(table, "doppelgangerRespectsEnemyImmunity", defaultGameSettings().doppelgangerRespectsEnemyImmunity);
+    settings.doppelgangerRespectsAllyImmunity = readSetting(table, "doppelgangerRespectsAllyImmunity", defaultGameSettings().doppelgangerRespectsAllyImmunity);
+    settings.leveledDoppelgangerAttack = readSetting(table, "leveledDoppelgangerAttack", defaultGameSettings().leveledDoppelgangerAttack);
+    settings.leveledTransformSelfAttack = readSetting(table, "leveledTransformSelfAttack", defaultGameSettings().leveledTransformSelfAttack);
+    settings.leveledTransformOtherAttack = readSetting(table, "leveledTransformOtherAttack", defaultGameSettings().leveledTransformOtherAttack);
+    settings.leveledDrainLevelAttack = readSetting(table, "leveledDrainLevelAttack", defaultGameSettings().leveledDrainLevelAttack);
+    settings.leveledSummonAttack = readSetting(table, "leveledSummonAttack", defaultGameSettings().leveledSummonAttack);
+    settings.missChanceSingleRoll = readSetting(table, "missChanceSingleRoll", defaultGameSettings().missChanceSingleRoll);
+    settings.unrestrictedBestowWards = readSetting(table, "unrestrictedBestowWards", defaultGameSettings().unrestrictedBestowWards);
+    settings.freeTransformSelfAttack = readSetting(table, "freeTransformSelfAttack", defaultGameSettings().freeTransformSelfAttack);
+    settings.freeTransformSelfAttackInfinite = readSetting(table, "freeTransformSelfAttackInfinite", defaultGameSettings().freeTransformSelfAttackInfinite);
+    settings.fixEffectiveHpFormula = readSetting(table, "fixEffectiveHpFormula", defaultGameSettings().fixEffectiveHpFormula);
+    settings.alchemistKeepsAttackCount = readSetting(table, "alchemistKeepsAttackCount", defaultGameSettings().alchemistKeepsAttackCount);
+    settings.instantBuffRemoval = readSetting(table, "instantBuffRemoval", defaultGameSettings().instantBuffRemoval);
+    settings.reviveAttacksUsesQtyHeal = readSetting(table, "reviveAttacksUsesQtyHeal", defaultGameSettings().reviveAttacksUsesQtyHeal);
+    settings.reviveItemsUsesQtyHeal = readSetting(table, "reviveItemsUsesQtyHeal", defaultGameSettings().reviveItemsUsesQtyHeal);
+    settings.advancedCure = readSetting(table, "advancedCure", defaultGameSettings().advancedCure);
 
     auto chances = table.get<sol::optional<sol::table>>("longEffectRemoveChances");
     if (chances.has_value())
@@ -618,18 +354,14 @@ static void readSettings(const sol::table& table, Settings& settings)
 
     readAiAttackPowerSettings(table, settings.aiAttackPowerBonus);
     readAllowBattleItemsSettings(table, settings.allowBattleItems);
-    readUnitEncyclopediaSettings(table, settings.unitEncyclopedia);
     readModifierSettings(table, settings.modifiers);
     readMovementCostSettings(table, settings.movementCost);
-    readLobbySettings(table, settings.lobby);
     readDebugSettings(table, settings.debug);
     readEngineSettings(table, settings.engine);
     readBattleSettings(table, settings.battle);
     readAdditionalLordIncomeSettings(table, settings.additionalLordIncome);
     readAdditionalCityIncomeSettings(table, settings.additionalCityIncome);
     readExtandedBattleSettings(table, settings.extendedBattle);
-    readCustomSortSettings(table, settings);
-    readHotkeySettings(table, settings.hotkeys);
 }
 
 static void readDebugMode(Settings& settings)
@@ -639,7 +371,7 @@ static void readDebugMode(Settings& settings)
     return;
 #endif
 
-    settings.debugMode = defaultSettings().debugMode;
+    settings.debugMode = defaultGameSettings().debugMode;
 
     char commandLine[256];
     strncpy(commandLine, GetCommandLine(), 256);
@@ -650,7 +382,7 @@ static void readDebugMode(Settings& settings)
     }
 }
 
-const Settings& baseSettings()
+const Settings& baseGameSettings()
 {
     static Settings settings;
     static bool initialized = false;
@@ -663,7 +395,6 @@ const Settings& baseSettings()
         settings.shatterDamageMax = 100;
         settings.drainAttackHeal = 50;
         settings.drainOverflowHeal = 50;
-        settings.carryOverItemsMax = 5;
         settings.criticalHitDamage = 5;
         settings.criticalHitChance = 100;
         settings.mageLeaderAttackPowerReduction = 10;
@@ -675,9 +406,6 @@ const Settings& baseSettings()
         settings.disableAllowedRoundMax = 40;
         settings.shatterDamageUpgradeRatio = 100;
         settings.splitDamageMultiplier = 1;
-        settings.showBanners = false;
-        settings.showResources = false;
-        settings.showLandConverted = false;
         settings.preserveCapitalBuildings = false;
         settings.buildTempleForWarriorLord = false;
         settings.allowShatterAttackToMiss = false;
@@ -692,16 +420,6 @@ const Settings& baseSettings()
         settings.unrestrictedBestowWards = false;
         settings.freeTransformSelfAttack = false;
         settings.freeTransformSelfAttackInfinite = false;
-        settings.unitEncyclopedia.detailedUnitDescription = false;
-        settings.unitEncyclopedia.detailedAttackDescription = false;
-        settings.unitEncyclopedia.displayDynamicUpgradeValues = false;
-        settings.unitEncyclopedia.displayBonusHp = false;
-        settings.unitEncyclopedia.displayBonusXp = false;
-        settings.unitEncyclopedia.displayInfiniteAttackIndicator = false;
-        settings.unitEncyclopedia.displayCriticalHitTextInAttackName = false;
-        settings.unitEncyclopedia.updateOnShiftKeyPress = false;
-        settings.unitEncyclopedia.updateOnCtrlKeyPress = false;
-        settings.unitEncyclopedia.updateOnAltKeyPress = false;
         settings.fixEffectiveHpFormula = false;
         settings.modifiers.cumulativeUnitRegeneration = false;
         settings.modifiers.notifyModifiersChanged = false;
@@ -720,9 +438,6 @@ const Settings& baseSettings()
         settings.movementCost.plain.dflt = 2;
         settings.movementCost.plain.deadLeader = 4;
         settings.movementCost.plain.onRoad = 1;
-        settings.movementCost.textColor = Color{200, 200, 200};
-        settings.movementCost.show = false;
-        settings.movementCost.showMovementAfterAction = false;
         settings.battle.fallbackAction = game::BattleAction::Defend;
         settings.debugMode = false;
 
@@ -741,15 +456,6 @@ const Settings& baseSettings()
         settings.extendedBattle.boostdamageCanAffectHealer = false;
 
         settings.longEffectRemoveChances = {0, 50, 75, 100};
-        settings.hotkeys.openSelectedObject.key = 'I';
-        settings.hotkeys.openSelectedObject.ctrl = false;
-        settings.hotkeys.openSelectedObject.shift = false;
-        settings.hotkeys.openSelectedObject.alt = false;
-
-        settings.hotkeys.quickSave.key = 'Q';
-        settings.hotkeys.quickSave.ctrl = true;
-        settings.hotkeys.quickSave.shift = false;
-        settings.hotkeys.quickSave.alt = false;
 
         initialized = true;
     }
@@ -757,19 +463,14 @@ const Settings& baseSettings()
     return settings;
 }
 
-const Settings& defaultSettings()
+const Settings& defaultGameSettings()
 {
     static Settings settings;
     static bool initialized = false;
 
     if (!initialized) {
-        settings = baseSettings();
-        settings.showBanners = true;
-        settings.showResources = true;
-        settings.movementCost.show = true;
+        settings = baseGameSettings();
         settings.unrestrictedBestowWards = true;
-        settings.unitEncyclopedia.detailedUnitDescription = true;
-        settings.unitEncyclopedia.detailedAttackDescription = true;
         settings.fixEffectiveHpFormula = true;
 
         // The default value of 1024 objects provides room for average object size of 512 bytes.
@@ -781,9 +482,9 @@ const Settings& defaultSettings()
     return settings;
 }
 
-void initializeUserSettings(Settings& value)
+void initializeGameSettings(Settings& value)
 {
-    value = defaultSettings();
+    value = defaultGameSettings();
 
     const auto path{scriptsFolder() / "settings.lua"};
     try {
@@ -801,27 +502,23 @@ void initializeUserSettings(Settings& value)
     }
 }
 
-Settings& getUserSettings()
+Settings& getGameSettings()
 {
     static Settings settings;
     static bool initialized = false;
 
     if (!initialized) {
-        initializeUserSettings(settings);
+        initializeGameSettings(settings);
         initialized = true;
     }
 
     return settings;
 }
 
-const Settings& userSettings()
+const Settings& gameSettings()
 {
-    return getUserSettings();
+    return getGameSettings();
 }
 
-Settings::Lobby& lobbySettings()
-{
-    return getUserSettings().lobby;
-}
 
 } // namespace hooks

--- a/mss32/src/transformotherhooks.cpp
+++ b/mss32/src/transformotherhooks.cpp
@@ -236,7 +236,7 @@ void __fastcall transformOtherAttackOnHitHooked(game::CBatAttackTransformOther* 
     if (transformImplId == emptyId)
         return;
 
-    if (userSettings().leveledTransformOtherAttack) {
+    if (gameSettings().leveledTransformOtherAttack) {
         const auto& global = GlobalDataApi::get();
         auto globalData = *global.getGlobalData();
 

--- a/mss32/src/transformselfhooks.cpp
+++ b/mss32/src/transformselfhooks.cpp
@@ -201,7 +201,7 @@ void giveFreeTransformSelfAttack(game::IMidgardObjectMap* objectMap,
         freeTransformSelf.turnCount--;   // Not counting transform action as a turn
 
     if (freeTransformSelf.used) {
-        if (!userSettings().freeTransformSelfAttackInfinite)
+        if (!gameSettings().freeTransformSelfAttackInfinite)
             return;
 
         // Prevents AI from falling into infinite transforming in case of targeting malfunction
@@ -336,7 +336,7 @@ void __fastcall transformSelfAttackOnHitHooked(game::CBatAttackTransformSelf* th
         return;
     }
 
-    if (userSettings().leveledTransformSelfAttack) {
+    if (gameSettings().leveledTransformSelfAttack) {
         const auto& global = GlobalDataApi::get();
         auto globalData = *global.getGlobalData();
 
@@ -365,7 +365,7 @@ void __fastcall transformSelfAttackOnHitHooked(game::CBatAttackTransformSelf* th
 
     if (!targetSelf)
         updateAttackCountAfterTransformation(battleMsgData, targetUnit, prevAttackTwice);
-    else if (userSettings().freeTransformSelfAttack)
+    else if (gameSettings().freeTransformSelfAttack)
         giveFreeTransformSelfAttack(objectMap, battleMsgData, targetUnit, prevAttackTwice);
 
     BattleAttackUnitInfo info{};

--- a/mss32/src/unitutils.cpp
+++ b/mss32/src/unitutils.cpp
@@ -520,7 +520,7 @@ game::IUsUnitExtension* castUnitImpl(const game::IUsUnit* unitImpl,
 
 int computeUnitEffectiveHpForAi(int hp, int armor)
 {
-    if (userSettings().fixEffectiveHpFormula) {
+    if (gameSettings().fixEffectiveHpFormula) {
         return computeUnitEffectiveHp(hp, armor);
     }
 
@@ -555,7 +555,7 @@ int computeShatterDamage(const game::CMidgardID* unitId,
 
     int armor = getArmor(unitId, soldier, battleMsgData, false, false);
 
-    int limit = userSettings().shatteredArmorMax
+    int limit = gameSettings().shatteredArmorMax
                 - battle.getUnitShatteredArmor(battleMsgData, unitId);
 
     int result = attack->vftable->getQtyDamage(attack);
@@ -563,8 +563,8 @@ int computeShatterDamage(const game::CMidgardID* unitId,
         result = armor;
     if (result > limit)
         result = limit;
-    if (result > userSettings().shatterDamageMax)
-        result = userSettings().shatterDamageMax;
+    if (result > gameSettings().shatterDamageMax)
+        result = gameSettings().shatterDamageMax;
 
     return result;
 }
@@ -603,13 +603,13 @@ bool isStackLeaderAndAllowedToUseBattleItems(const game::IMidgardObjectMap* obje
         return false;
 
     if (battleApi.getUnitStatus(battleMsgData, unitId, BattleStatus::Transform))
-        return userSettings().allowBattleItems.onTransformOther;
+        return gameSettings().allowBattleItems.onTransformOther;
     else if (battleApi.getUnitStatus(battleMsgData, unitId, BattleStatus::TransformSelf))
-        return userSettings().allowBattleItems.onTransformSelf;
+        return gameSettings().allowBattleItems.onTransformSelf;
     else if (battleApi.getUnitStatus(battleMsgData, unitId, BattleStatus::TransformDrainLevel))
-        return userSettings().allowBattleItems.onDrainLevel;
+        return gameSettings().allowBattleItems.onDrainLevel;
     else if (battleApi.getUnitStatus(battleMsgData, unitId, BattleStatus::TransformDoppelganger))
-        return userSettings().allowBattleItems.onDoppelganger;
+        return gameSettings().allowBattleItems.onDoppelganger;
 
     return true;
 }

--- a/mss32/src/usersettings.cpp
+++ b/mss32/src/usersettings.cpp
@@ -1,0 +1,468 @@
+/*
+ * This file is part of the modding toolset for Disciples 2.
+ * (https://github.com/VladimirMakeev/D2ModdingToolset)
+ * Copyright (C) 2020 Vladimir Makeev.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "usersettings.h"
+
+#include "scripts.h"
+#include "utils.h"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <spdlog/spdlog.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+namespace hooks {
+
+template <typename T>
+static T readSetting(const sol::table& table,
+                     const char* name,
+                     T def,
+                     T min = std::numeric_limits<T>::min(),
+                     T max = std::numeric_limits<T>::max())
+{
+    return std::clamp<T>(table.get_or(name, def), min, max);
+}
+
+static std::string readSetting(const sol::table& table, const char* name, const std::string& def)
+{
+    return table.get_or(name, def);
+}
+
+static Color readColor(const sol::table& table, const Color& def)
+{
+    Color color{};
+    color.r = readSetting(table, "red", def.r);
+    color.g = readSetting(table, "green", def.g);
+    color.b = readSetting(table, "blue", def.b);
+
+    return color;
+}
+
+static void readCustomSortSettings(const sol::table& table, UserSettings& settings)
+{
+    settings.customSortOrder.clear();
+
+    auto arr = table.get<sol::optional<sol::table>>("customSortOrder");
+    if (!arr.has_value())
+        return;
+
+    for (auto& kv : arr.value())
+        settings.customSortOrder.push_back(kv.second.as<std::string>());
+}
+
+static std::uint32_t parseKeyCode(std::string key)
+{
+    std::transform(key.begin(), key.end(), key.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+
+    if (key.empty())
+        return 0;
+
+    if (key.size() == 1)
+        return key[0];
+
+    static const std::unordered_map<std::string, std::uint32_t> keys = {
+        {"TAB", VK_TAB},           {"SPACE", VK_SPACE},     {"ENTER", VK_RETURN},
+        {"RETURN", VK_RETURN},     {"ESC", VK_ESCAPE},      {"ESCAPE", VK_ESCAPE},
+        {"BACKSPACE", VK_BACK},    {"DELETE", VK_DELETE},   {"INSERT", VK_INSERT},
+        {"HOME", VK_HOME},         {"END", VK_END},         {"PAGEUP", VK_PRIOR},
+        {"PAGEDOWN", VK_NEXT},
+
+        {"LEFT", VK_LEFT},         {"RIGHT", VK_RIGHT},     {"UP", VK_UP},
+        {"DOWN", VK_DOWN},
+
+        {"CTRL", VK_CONTROL},      {"SHIFT", VK_SHIFT},     {"ALT", VK_MENU},
+
+        {"NUM0", VK_NUMPAD0},      {"NUM1", VK_NUMPAD1},    {"NUM2", VK_NUMPAD2},
+        {"NUM3", VK_NUMPAD3},      {"NUM4", VK_NUMPAD4},    {"NUM5", VK_NUMPAD5},
+        {"NUM6", VK_NUMPAD6},      {"NUM7", VK_NUMPAD7},    {"NUM8", VK_NUMPAD8},
+        {"NUM9", VK_NUMPAD9},
+
+        {"PLUS", VK_OEM_PLUS},     {"MINUS", VK_OEM_MINUS}, {"COMMA", VK_OEM_COMMA},
+        {"PERIOD", VK_OEM_PERIOD},
+    };
+
+    auto it = keys.find(key);
+    if (it != keys.end())
+        return it->second;
+
+    if (key[0] == 'F') {
+        int number = std::atoi(key.c_str() + 1);
+        if (number >= 1 && number <= 24)
+            return VK_F1 + number - 1;
+    }
+
+    return 0;
+}
+
+static std::string keyCodeToString(std::uint32_t key)
+{
+    if (key >= 'A' && key <= 'Z')
+        return std::string(1, static_cast<char>(key));
+
+    if (key >= '0' && key <= '9')
+        return std::string(1, static_cast<char>(key));
+
+    if (key >= VK_F1 && key <= VK_F24)
+        return "F" + std::to_string(key - VK_F1 + 1);
+
+    switch (key) {
+    case VK_TAB:
+        return "TAB";
+    case VK_SPACE:
+        return "SPACE";
+    case VK_RETURN:
+        return "ENTER";
+    case VK_ESCAPE:
+        return "ESC";
+    case VK_BACK:
+        return "BACKSPACE";
+    case VK_DELETE:
+        return "DELETE";
+    case VK_INSERT:
+        return "INSERT";
+    case VK_HOME:
+        return "HOME";
+    case VK_END:
+        return "END";
+    case VK_PRIOR:
+        return "PAGEUP";
+    case VK_NEXT:
+        return "PAGEDOWN";
+
+    case VK_LEFT:
+        return "LEFT";
+    case VK_RIGHT:
+        return "RIGHT";
+    case VK_UP:
+        return "UP";
+    case VK_DOWN:
+        return "DOWN";
+
+    case VK_NUMPAD0:
+        return "NUM0";
+    case VK_NUMPAD1:
+        return "NUM1";
+    case VK_NUMPAD2:
+        return "NUM2";
+    case VK_NUMPAD3:
+        return "NUM3";
+    case VK_NUMPAD4:
+        return "NUM4";
+    case VK_NUMPAD5:
+        return "NUM5";
+    case VK_NUMPAD6:
+        return "NUM6";
+    case VK_NUMPAD7:
+        return "NUM7";
+    case VK_NUMPAD8:
+        return "NUM8";
+    case VK_NUMPAD9:
+        return "NUM9";
+
+    case VK_OEM_PLUS:
+        return "PLUS";
+    case VK_OEM_MINUS:
+        return "MINUS";
+    case VK_OEM_COMMA:
+        return "COMMA";
+    case VK_OEM_PERIOD:
+        return "PERIOD";
+    }
+
+    return "";
+}
+static void readHotkey(const sol::table& table, const char* name, Hotkey& value, const Hotkey& def)
+{
+    auto hotkey = table.get<sol::optional<sol::table>>(name);
+    if (!hotkey.has_value()) {
+        value = def;
+        return;
+    }
+
+    value.key = parseKeyCode(readSetting(hotkey.value(), "key", keyCodeToString(def.key)));
+
+    value.ctrl = readSetting(hotkey.value(), "ctrl", def.ctrl);
+    value.shift = readSetting(hotkey.value(), "shift", def.shift);
+    value.alt = readSetting(hotkey.value(), "alt", def.alt);
+}
+
+static void readHotkeySettings(const sol::table& table, Hotkeys& value)
+{
+    const auto& def = defaultUserSettings().hotkeys;
+
+    value = def;
+
+    auto category = table.get<sol::optional<sol::table>>("hotkeys");
+    if (!category.has_value())
+        return;
+
+    readHotkey(category.value(), "openSelectedObject", value.openSelectedObject,
+               def.openSelectedObject);
+
+    readHotkey(category.value(), "quickSave", value.quickSave, def.quickSave);
+}
+
+static void readUnitEncyclopediaSettings(const sol::table& table, UnitEncyclopedia& value)
+{
+    const auto& def = defaultUserSettings().unitEncyclopedia;
+
+    auto category = table.get<sol::optional<sol::table>>("unitEncyclopedia");
+    if (!category.has_value()) {
+        value = def;
+
+        // Backward compatibility
+        value.detailedAttackDescription = readSetting(table, "detailedAttackDescription",
+                                                      def.detailedAttackDescription);
+        return;
+    }
+
+    value.detailedUnitDescription = readSetting(category.value(), "detailedUnitDescription",
+                                                def.detailedUnitDescription);
+
+    value.detailedAttackDescription = readSetting(category.value(), "detailedAttackDescription",
+                                                  def.detailedAttackDescription);
+
+    value.displayDynamicUpgradeValues = readSetting(category.value(), "displayDynamicUpgradeValues",
+                                                    def.displayDynamicUpgradeValues);
+
+    value.displayBonusHp = readSetting(category.value(), "displayBonusHp", def.displayBonusHp);
+
+    value.displayBonusXp = readSetting(category.value(), "displayBonusXp", def.displayBonusXp);
+
+    value.displayInfiniteAttackIndicator = readSetting(category.value(),
+                                                       "displayInfiniteAttackIndicator",
+                                                       def.displayInfiniteAttackIndicator);
+
+    value.displayCriticalHitTextInAttackName = readSetting(category.value(),
+                                                           "displayCriticalHitTextInAttackName",
+                                                           def.displayCriticalHitTextInAttackName);
+
+    value.updateOnShiftKeyPress = readSetting(category.value(), "updateOnShiftKeyPress",
+                                              def.updateOnShiftKeyPress);
+
+    value.updateOnCtrlKeyPress = readSetting(category.value(), "updateOnCtrlKeyPress",
+                                             def.updateOnCtrlKeyPress);
+
+    value.updateOnAltKeyPress = readSetting(category.value(), "updateOnAltKeyPress",
+                                            def.updateOnAltKeyPress);
+}
+static void readMovementDisplaySettings(const sol::table& table, MovementDisplay& value)
+{
+    const auto& def = defaultUserSettings().movementDisplay;
+
+    value = def;
+
+    auto movement = table.get<sol::optional<sol::table>>("movementCost");
+    if (!movement.has_value())
+        return;
+
+    value.show = readSetting(movement.value(), "show", def.show);
+
+    value.showMovementAfterAction = readSetting(movement.value(), "showMovementAfterAction",
+                                                def.showMovementAfterAction);
+
+    auto textColor = movement.value().get<sol::optional<sol::table>>("textColor");
+
+    if (textColor.has_value())
+        value.textColor = readColor(textColor.value(), def.textColor);
+
+    auto outlineColor = movement.value().get<sol::optional<sol::table>>("outlineColor");
+
+    if (outlineColor.has_value())
+        value.outlineColor = readColor(outlineColor.value(), def.outlineColor);
+}
+
+static void readLobbySettings(const sol::table& table, Lobby& value)
+{
+    const auto& def = defaultUserSettings().lobby;
+
+    value.server.ip = def.server.ip;
+    value.server.port = def.server.port;
+    value.client.port = def.client.port;
+
+    auto lobby = table.get<sol::optional<sol::table>>("lobby");
+    if (!lobby.has_value())
+        return;
+
+    auto server = lobby.value().get<sol::optional<sol::table>>("server");
+
+    if (server.has_value()) {
+        value.server.ip = readSetting(server.value(), "ip", def.server.ip);
+
+        value.server.port = readSetting(server.value(), "port", def.server.port);
+    }
+
+    auto client = lobby.value().get<sol::optional<sol::table>>("client");
+
+    if (client.has_value()) {
+        value.client.port = readSetting(client.value(), "port", def.client.port);
+    }
+}
+static void readUserSettings(const sol::table& table, UserSettings& settings)
+{
+    settings.showBanners = readSetting(table, "showBanners", defaultUserSettings().showBanners);
+
+    settings.showResources = readSetting(table, "showResources",
+                                         defaultUserSettings().showResources);
+
+    settings.showLandConverted = readSetting(table, "showLandConverted",
+                                             defaultUserSettings().showLandConverted);
+    settings.carryOverItemsMax = readSetting(table, "carryOverItemsMax",
+                                             defaultUserSettings().carryOverItemsMax, 0);
+
+    readCustomSortSettings(table, settings);
+    readHotkeySettings(table, settings.hotkeys);
+    readUnitEncyclopediaSettings(table, settings.unitEncyclopedia);
+    readMovementDisplaySettings(table, settings.movementDisplay);
+    readLobbySettings(table, settings.lobby);
+}
+
+const UserSettings& baseUserSettings()
+{
+    static UserSettings settings;
+    static bool initialized = false;
+
+    if (!initialized) {
+
+        settings.showBanners = false;
+        settings.showResources = false;
+        settings.showLandConverted = false;
+
+        settings.carryOverItemsMax = 5;
+
+        settings.unitEncyclopedia.detailedUnitDescription = false;
+        settings.unitEncyclopedia.detailedAttackDescription = false;
+        settings.unitEncyclopedia.displayDynamicUpgradeValues = false;
+        settings.unitEncyclopedia.displayBonusHp = false;
+        settings.unitEncyclopedia.displayBonusXp = false;
+        settings.unitEncyclopedia.displayInfiniteAttackIndicator = false;
+        settings.unitEncyclopedia.displayCriticalHitTextInAttackName = false;
+        settings.unitEncyclopedia.updateOnShiftKeyPress = false;
+        settings.unitEncyclopedia.updateOnCtrlKeyPress = false;
+        settings.unitEncyclopedia.updateOnAltKeyPress = false;
+
+        settings.movementDisplay.show = false;
+        settings.movementDisplay.showMovementAfterAction = false;
+        settings.movementDisplay.textColor = {200, 200, 200};
+        settings.movementDisplay.outlineColor = {0, 0, 0};
+
+        settings.hotkeys.openSelectedObject.key = 'I';
+        settings.hotkeys.openSelectedObject.ctrl = false;
+        settings.hotkeys.openSelectedObject.shift = false;
+        settings.hotkeys.openSelectedObject.alt = false;
+
+        settings.hotkeys.quickSave.key = 'Q';
+        settings.hotkeys.quickSave.ctrl = true;
+        settings.hotkeys.quickSave.shift = false;
+        settings.hotkeys.quickSave.alt = false;
+
+        initialized = true;
+    }
+
+    return settings;
+}
+
+const UserSettings& defaultUserSettings()
+{
+    static UserSettings settings;
+    static bool initialized = false;
+
+    if (!initialized) {
+
+        
+        const auto& base = baseUserSettings();
+        settings = base;
+
+        settings.showBanners = true;
+        settings.showResources = true;
+
+        settings.unitEncyclopedia.detailedUnitDescription = true;
+        settings.unitEncyclopedia.detailedAttackDescription = true;
+
+        settings.movementDisplay.show = true;
+
+        initialized = true;
+    }
+
+    return settings;
+}
+
+
+
+static std::optional<sol::environment> settingsEnvironment;
+
+const sol::environment* userSettingsEnvironment()
+{
+    return settingsEnvironment ? &*settingsEnvironment : nullptr;
+}
+
+static void initializeUserSettings(UserSettings& value)
+{
+    value = defaultUserSettings();
+
+    const auto path{scriptsFolder() / "userSettings.lua"};
+
+    try {
+
+        settingsEnvironment = executeUserSettingsFile(path);
+
+        if (settingsEnvironment) {
+            const sol::table& table = (*settingsEnvironment)["settings"];
+            readUserSettings(table, value);
+        }
+
+    } catch (const std::exception& e) {
+
+        showErrorMessageBox(fmt::format("Failed to read script '{:s}'.\n"
+                                        "Reason: '{:s}'",
+                                        path.string(), e.what()));
+    }
+}
+
+static UserSettings& getUserSettings()
+{
+    static UserSettings settings;
+    static bool initialized = false;
+
+    if (!initialized) {
+        initializeUserSettings(settings);
+        initialized = true;
+    }
+
+    return settings;
+}
+
+const UserSettings& userSettings()
+{
+    return getUserSettings();
+}
+
+Lobby& lobbySettings()
+{
+    return getUserSettings().lobby;
+}
+
+
+
+} // namespace hooks


### PR DESCRIPTION
Split gameplay and user settings into separate configuration files.

The original settings.lua mixed gameplay-affecting options with purely client-side
preferences. This caused unnecessary multiplayer file verification conflicts and
made it impossible for players to customize local UI and QoL settings independently.

Changes:
- Added userSettings.lua for client-side settings excluded from multiplayer file verification.
- Kept gameplay-affecting options in settings.lua.
- Added a dedicated user settings loader and sandboxed Lua environment.
- Introduced UserSettings and UserSettingsView APIs for convenient access from C++ and Lua bindings.
- Added safe execution of userSettings.lua without exposing game globals.
- Moved UI and convenience options (hotkeys, lobby configuration, inventory sorting,
  movement display, encyclopedia display options, etc.) into userSettings.lua.
- Updated README and documentation to reflect the new configuration layout.

Also fixed a lobby compatibility issue that could prevent joining multiplayer rooms
when game settings differed only by user-specific configuration files. User settings
are now ignored during multiplayer compatibility verification, allowing players to
use their own local preferences without affecting room compatibility.