### PR TITLE
fix: complete thief Lua API integration 

### DIFF
--- a/Scripts/theft.lua
+++ b/Scripts/theft.lua
@@ -1,0 +1,266 @@
+--
+-- Called before an item can be stolen from a Merchant or a spell can be
+-- stolen from a Mage Tower.
+--
+-- Return value:
+--   true  - allow stealing.
+--   false - prevent stealing.
+--
+-- These callbacks can be used to:
+--   * forbid stealing specific items or spells;
+--   * restrict stealing by player race or lord;
+--   * inspect the Merchant or Mage Tower contents;
+--   * implement custom stealing rules.
+--
+--
+-- Returning true allows the current item or spell to be stolen.
+-- Return false to block stealing.
+--
+
+--
+-- Example 1:
+-- Prevent stealing a specific item.
+--
+-- if item.id == "g000ig0005" then
+--     return false
+-- end
+
+--
+-- Example 2:
+-- Allow stealing only low-level spells.
+--
+-- if spell.level > 3 then
+--     return false
+-- end
+
+function theftFilterItemsMerchant(stealItemContext)
+
+    log("")
+    log("========================================")
+    log("===== THEFT FILTER ITEMS MERCHANT ======")
+    log("========================================")
+
+    --
+    -- Player
+    --
+
+    local player = stealItemContext.player
+
+    log("")
+    log("PLAYER")
+    log("id        : " .. tostring(player.id))
+    log("race      : " .. player.race)
+    log("lord      : " .. player.lord)
+    log("human     : " .. tostring(player.human))
+    log("alwaysAi  : " .. tostring(player.alwaysAi))
+
+    log("bank      : " .. tostring(player.bank))
+    log("gold      : " .. player.bank.gold)
+    log("infernal  : " .. player.bank.infernalMana)
+    log("life      : " .. player.bank.lifeMana)
+    log("death     : " .. player.bank.deathMana)
+    log("runic     : " .. player.bank.runicMana)
+    log("grove     : " .. player.bank.groveMana)
+
+    --
+    -- Merchant
+    --
+
+    local merchant = stealItemContext.merchant
+
+    log("")
+    log("MERCHANT")
+    log("id        : " .. tostring(merchant.id))
+    log("position  : (" ..
+        merchant.position.x .. ", " ..
+        merchant.position.y .. ")")
+
+    log("mission   : " .. tostring(merchant.mission))
+
+    log("visitors  : " .. #merchant.visitors)
+
+    for i, visitor in ipairs(merchant.visitors) do
+        log(string.format(
+            "visitor[%d] : %s",
+            i,
+            tostring(visitor.id)))
+    end
+
+    log("items     : " .. #merchant.items)
+
+    for i, merchantItem in ipairs(merchant.items) do
+
+        local base = merchantItem.base
+
+        log(string.format(
+            "item[%d]    : %s x%d",
+            i,
+            tostring(base.id),
+            merchantItem.amount))
+    end
+
+    --
+    -- Item
+    --
+
+    local item = stealItemContext.item
+
+    log("")
+    log("ITEM")
+    log("id        : " .. tostring(item.id))
+    log("type      : " .. item.type)
+
+    log("value     : " .. tostring(item.value))
+    log("gold      : " .. item.value.gold)
+    log("infernal  : " .. item.value.infernalMana)
+    log("life      : " .. item.value.lifeMana)
+    log("death     : " .. item.value.deathMana)
+    log("runic     : " .. item.value.runicMana)
+    log("grove     : " .. item.value.groveMana)
+
+    if item.unitImpl then
+        log("unitImpl  : " .. tostring(item.unitImpl.id))
+    else
+        log("unitImpl  : nil")
+    end
+
+    if item.attack then
+        log("attack    : " .. tostring(item.attack.id))
+    else
+        log("attack    : nil")
+    end
+
+    log("")
+    log("========================================")
+
+    return true
+end
+
+
+function theftFilterMageTower(stealSpellContext)
+
+    log("")
+    log("========================================")
+    log("======= THEFT FILTER MAGE TOWER ========")
+    log("========================================")
+
+    --
+    -- Player
+    --
+
+    local player = stealSpellContext.player
+
+    log("")
+    log("PLAYER")
+
+    log("id        : " .. tostring(player.id))
+    log("race      : " .. player.race)
+    log("lord      : " .. player.lord)
+    log("human     : " .. tostring(player.human))
+    log("alwaysAi  : " .. tostring(player.alwaysAi))
+
+    log("bank      : " .. tostring(player.bank))
+    log("gold      : " .. player.bank.gold)
+    log("infernal  : " .. player.bank.infernalMana)
+    log("life      : " .. player.bank.lifeMana)
+    log("death     : " .. player.bank.deathMana)
+    log("runic     : " .. player.bank.runicMana)
+    log("grove     : " .. player.bank.groveMana)
+
+    --
+    -- Mage Tower
+    --
+
+    local siteMage = stealSpellContext.mage
+
+    log("")
+    log("SITE MAGE")
+
+    log("id        : " .. tostring(siteMage.id))
+    log("position  : (" ..
+        siteMage.position.x .. ", " ..
+        siteMage.position.y .. ")")
+
+    log("visitors  : " .. #siteMage.visitors)
+
+    for i, visitor in ipairs(siteMage.visitors) do
+        log(string.format(
+            "visitor[%d] : %s",
+            i,
+            tostring(visitor.id)))
+    end
+
+    log("spells    : " .. #siteMage.spells)
+
+    for i, spellId in ipairs(siteMage.spells) do
+        log(string.format(
+            "spell[%d]   : %s",
+            i,
+            tostring(spellId)))
+    end
+
+    --
+    -- Spell
+    --
+
+    local spell = stealSpellContext.spell
+
+    log("")
+    log("SPELL")
+
+    log("id             : " .. tostring(spell.id))
+    log("type           : " .. spell.type)
+    log("level          : " .. spell.level)
+
+    log("castingCost    : " .. tostring(spell.castingCost))
+    log("buyCost        : " .. tostring(spell.buyCost))
+
+    log("cast gold      : " .. spell.castingCost.gold)
+    log("cast infernal  : " .. spell.castingCost.infernalMana)
+    log("cast life      : " .. spell.castingCost.lifeMana)
+    log("cast death     : " .. spell.castingCost.deathMana)
+    log("cast runic     : " .. spell.castingCost.runicMana)
+    log("cast grove     : " .. spell.castingCost.groveMana)
+
+    log("buy gold       : " .. spell.buyCost.gold)
+    log("buy infernal   : " .. spell.buyCost.infernalMana)
+    log("buy life       : " .. spell.buyCost.lifeMana)
+    log("buy death      : " .. spell.buyCost.deathMana)
+    log("buy runic      : " .. spell.buyCost.runicMana)
+    log("buy grove      : " .. spell.buyCost.groveMana)
+
+    log("restoreMove    : " .. spell.restoreMove)
+    log("area           : " .. spell.area)
+    log("damage         : " .. spell.damage)
+    log("heal           : " .. spell.heal)
+    log("ground         : " .. spell.ground)
+    log("changeTerrain  : " .. tostring(spell.changeTerrain))
+    log("aiType         : " .. spell.aiType)
+    log("damageSource   : " .. spell.damageSource)
+
+    if spell.unit then
+        log("unit           : " .. tostring(spell.unit.id))
+    else
+        log("unit           : nil")
+    end
+
+    if spell.modifier then
+        log("modifier       : " .. tostring(spell.modifier.id))
+    else
+        log("modifier       : nil")
+    end
+
+    log("wards          : " .. #spell.wards)
+
+    for i, ward in ipairs(spell.wards) do
+        log(string.format(
+            "ward[%d]       : %s",
+            i,
+            tostring(ward.id)))
+    end
+
+    log("")
+    log("========================================")
+
+    return true
+end

--- a/luaApi.md
+++ b/luaApi.md
@@ -6,6 +6,7 @@ Scripts folder itself should be placed in the game folder.
 
 ### Currently used scripts and their meanings:
 - settings.lua - mss32 proxy dll settings that changes game rules
+- userSettings.lua - user-specific mss32 proxy dll settings that are excluded from multiplayer lobby hash verification and affect only the local user
 - doppelganger.lua - logic that computes level of doppelganger transform (category L\_DOPPELGANGER)
 - transformSelf.lua - computes unit level and determines free attacks to give for transform-self attacks (category L\_TRANSFORM\_SELF)
 - transformOther.lua - computes unit level for transform-other attacks (category L\_TRANSFORM\_OTHER)
@@ -24,6 +25,75 @@ Scripts folder itself should be placed in the game folder.
 - getWoundedFemaleGreenskinTargets.lua - contains targeting logic that only allows to reach wounded female greenskins
 - [Scripts/Modifiers](Scripts/Modifiers) - contains custom modifier script examples
 - unitEncyclopedia.lua - contains custom display functions for unit encyclopedia
+- theft.lua - Contains filtering logic for spells that can be stolen from Mage Towers and items that can be stolen from Merchants
+
+
+
+### theft.lua (Stealing filters)
+
+Contains filtering logic for spells that can be stolen from Mage Towers
+and items that can be stolen from Merchants.
+
+The script is optional.
+If it is absent or a function is not defined, the default game logic is used.
+
+Supported functions:
+
+```lua
+-- Called for every spell available in Mage Tower.
+function theftFilterMageTower(context)
+    return true
+end
+
+-- Called for every item available from Merchant.
+function theftFilterItemsMerchant(context)
+    return true
+end
+```
+
+
+Both functions must return:
+
+- `true` — object is shown in the steal dialog.
+- `false` — object is hidden.
+ 
+Both functions are called once for every available spell or item.
+ 
+#### theftFilterMageTower(context)
+
+Context fields:
+
+```lua
+context.player    -- PlayerView
+context.mage      -- MageTowerView
+context.spell     -- SpellView
+```
+
+Example:
+
+```lua
+function theftFilterMageTower(context)
+    return context.spell.level <= 3
+end
+```
+
+#### theftFilterItemsMerchant(context)
+
+Context fields:
+
+```lua
+context.player     -- PlayerView
+context.merchant   -- MerchantView
+context.item       -- ItemBaseView
+```
+
+Example:
+
+```lua
+function theftFilterItemsMerchant(context)
+    return context.item.value.gold <= 1000
+end
+```
 
 ### API reference
 

--- a/mss32/include/stealitemhooks.h
+++ b/mss32/include/stealitemhooks.h
@@ -51,7 +51,7 @@ struct StealItemBuildContext
 
 extern thread_local StealItemBuildContext g_stealItemCtx;
 
-bool shouldDisplayStealItem(const game::CMidgardID* merchantId, game::StealItemEntry* entry);
+bool shouldDisplayStealItem(game::StealItemEntry* entry);
 
 void* getStealItemCtorHooked();
 

--- a/mss32/include/stealmerchantiteminterf.h
+++ b/mss32/include/stealmerchantiteminterf.h
@@ -17,11 +17,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 // ============================================================
 // File: stealmerchantiteminterf.h
 // ============================================================
-
 
 #ifndef STEALMERCHANTITEMINTERF_H
 #define STEALMERCHANTITEMINTERF_H
@@ -45,8 +43,11 @@ namespace StealMerchantItemInterfApi {
 
 struct Api
 {
-    using Constructor =
-        CMidDragDropInterf*(__thiscall*)(void* thisptr, int a2, int functor, int a4, void* a5);
+    using Constructor = CMidDragDropInterf*(__thiscall*)(void* thisptr,
+                                                         int a2,
+                                                         int functor,
+                                                         int a4,
+                                                         const game::CMidgardID* merchantId);
 
     Constructor constructor;
 
@@ -57,18 +58,6 @@ struct Api
     using AddStealItem = char*(__thiscall*)(void* thisptr, StealItemEntry* entry);
 
     AddStealItem addStealItem;
-
-    //
-    // helper wrappers (not work)
-    //
-
-    using GetMerchantId = game::CMidgardID*(__thiscall*)(void* thisptr);
-
-    GetMerchantId getMerchantId;
-
-    using GetItemVector = void*(__thiscall*)(void* thisptr);
-
-    GetItemVector getItemVector;
 };
 
 Api& get();

--- a/mss32/include/stealspellinterf.h
+++ b/mss32/include/stealspellinterf.h
@@ -21,9 +21,8 @@
 // File: stealspellinterf.h
 // ============================================================
 
-
-#include "MIDDRAGDROPINTERF.H"
-#include "MIDGARDOBJECTMAP.H"
+#include "middragdropinterf.h"
+#include "midgardobjectmap.h"
 
 #ifndef STEALSPELLINTERF_H
 #define STEALSPELLINTERF_H
@@ -45,12 +44,11 @@ struct Api
 
     GetListBox getListBox;
 
-   using BuildSpellList = bool(__stdcall*)(const game::IMidgardObjectMap*,
+    using BuildSpellList = bool(__stdcall*)(const game::IMidgardObjectMap*,
                                             game::CMidgardID,
                                             game::CMidgardID,
                                             void*);
     BuildSpellList buildSpellList;
-
 };
 
 Api& get();

--- a/mss32/src/addstealspellhooks.cpp
+++ b/mss32/src/addstealspellhooks.cpp
@@ -23,18 +23,22 @@
 
 #include "addstealspellhooks.h"
 
-#include "DYNAMICCAST.h"
-#include "MIDGARDOBJECTMAP.h"
-#include "MIDSITEMAGE.h"
 #include "button.h"
+#include "dynamiccast.h"
 #include "game.h"
 #include "gameutils.h"
 #include "globaldata.h"
 #include "globalvariables.h"
 #include "idset.h"
+#include "itembase.h"
+#include "itembaseview.h"
 #include "listbox.h"
 #include "midgardid.h"
+#include "midgardobjectmap.h"
+#include "midplayer.h"
 #include "midpopupinterf.h"
+#include "midsite.h"
+#include "midsitemage.h"
 #include "scripts.h"
 #include "spellutils.h"
 #include "spellview.h"
@@ -47,6 +51,8 @@
 #include <string>
 
 #include <dialoginterf.h>
+#include <magetowerview.h>
+#include <merchantview.h>
 #include <sol/sol.hpp>
 #include <spdlog/spdlog.h>
 
@@ -96,23 +102,6 @@ static SortedInsert sortedInsertOrig;
 using StealSpellCtor = game::CMidDragDropInterf*(__thiscall*)(void*, int, int, int, void*);
 
 static StealSpellCtor stealSpellCtorOrig;
-
-//
-// debug
-//
-
-static std::string midgardIdToDebugString(const game::CMidgardID* id)
-{
-    if (!id) {
-        return "null";
-    }
-
-    char buffer[32]{};
-
-    game::CMidgardIDApi::get().toString(id, buffer);
-
-    return std::string(buffer);
-}
 
 //
 // helpers
@@ -189,6 +178,21 @@ bool shouldDisplayStealSpell(const game::CMidgardID* spellId)
         return false;
     }
 
+    auto objectMap = g_stealSpellCtx.objectMap;
+
+    auto playerObj = objectMap->vftable->findScenarioObjectById(objectMap,
+                                                                &g_stealSpellCtx.playerId);
+
+    auto mageObj = objectMap->vftable->findScenarioObjectById(objectMap, &g_stealSpellCtx.mageId);
+
+    if (!playerObj || !mageObj) {
+        return false;
+    }
+
+    auto player = static_cast<game::CMidPlayer*>(playerObj);
+
+    auto mageTower = static_cast<game::CMidSiteMage*>(mageObj);
+
     //
     // lua has priority
     //
@@ -221,9 +225,9 @@ bool shouldDisplayStealSpell(const game::CMidgardID* spellId)
 
             sol::table stealSpellContext = lua.create_table();
 
-            stealSpellContext["mageTowerId"] = &g_stealSpellCtx.mageId;
+            stealSpellContext["mage"] = bindings::MageTowerView(mageTower, objectMap);
 
-            stealSpellContext["playerId"] =&g_stealSpellCtx.playerId;
+            stealSpellContext["player"] = bindings::PlayerView(player, objectMap);
 
             stealSpellContext["spell"] = bindings::SpellView(spell);
 
@@ -275,15 +279,12 @@ bool __stdcall buildSpellListHooked(const game::IMidgardObjectMap* objectMap,
                                     const game::CMidgardID* playerId,
                                     void* list)
 {
-    spdlog::info("[STEAL_SPELL] build start");
 
     auto mageObj = objectMap->vftable->findScenarioObjectById(objectMap, mageId);
 
     auto playerObj = objectMap->vftable->findScenarioObjectById(objectMap, playerId);
 
     if (!mageObj || !playerObj) {
-
-        spdlog::info("[STEAL_SPELL] failed to resolve objects");
 
         return buildSpellListOrig(objectMap, mageId, playerId, list);
     }
@@ -326,9 +327,6 @@ bool __stdcall buildSpellListHooked(const game::IMidgardObjectMap* objectMap,
     //
 
     g_stealSpellCtx.active = false;
-
-    spdlog::info("[STEAL_SPELL] visible spells");
-    spdlog::info(g_stealSpellCtx.insertedCount);
 
     return result;
 }

--- a/mss32/src/scripts.cpp
+++ b/mss32/src/scripts.cpp
@@ -45,6 +45,7 @@
 #include "itemview.h"
 #include "landmarkview.h"
 #include "locationview.h"
+#include "magetowerview.h"
 #include "merchantview.h"
 #include "mercsview.h"
 #include "midstack.h"
@@ -509,6 +510,7 @@ static void bindApi(sol::state& lua)
     bindings::SiteView::bind(lua);
     bindings::MerchantItemView::bind(lua);
     bindings::MerchantView::bind(lua);
+    bindings::MageTowerView::bind(lua);
     bindings::MercenaryUnitView::bind(lua);
     bindings::MercsView::bind(lua);
     bindings::TrainerView::bind(lua);
@@ -598,26 +600,8 @@ sol::environment executeUserSettingsScript(const std::string& source,
 {
     auto& lua = getLua();
 
-    // Completely isolated environment for user settings.
+    //  isolated (empty) environment for user settings.
     sol::environment env(lua, sol::create);
-
-    // Optional: expose only the standard Lua library if needed.
-    // env["pairs"] = lua["pairs"];
-    // env["ipairs"] = lua["ipairs"];
-    // env["next"] = lua["next"];
-    // env["type"] = lua["type"];
-    // env["math"] = lua["math"];
-    // env["table"] = lua["table"];
-    // env["string"] = lua["string"];
-
-    /*env["io"] = sol::nil;
-    env["os"] = sol::nil;
-    env["package"] = sol::nil;
-    env["require"] = sol::nil;
-    env["load"] = sol::nil;
-    env["loadfile"] = sol::nil;
-    env["dofile"] = sol::nil;
-    env["debug"] = sol::nil;*/
 
     env["assert"] = lua["assert"];
     env["error"] = lua["error"];

--- a/mss32/src/stealitemhooks.cpp
+++ b/mss32/src/stealitemhooks.cpp
@@ -28,24 +28,29 @@
 #include "button.h"
 #include "dialoginterf.h"
 
+#include "midpopupinterf.h"
+#include "draganddropinterf.h"
 #include "game.h"
 #include "gameutils.h"
 #include "globaldata.h"
 #include "globalvariables.h"
+#include "itembase.h"
+#include "itembaseview.h"
 #include "midgardobjectmap.h"
+#include "midplayer.h"
+#include "midsite.h"
 #include "midsitemerchant.h"
-#include "draganddropinterf.h"
-#include "POPUPINTERF.h"
 #include "phasegame.h"
+#include "playerview.h"
 #include "scripts.h"
-#include "utils.h"
 #include "task.h"
+#include "utils.h"
 
 #include <algorithm>
+#include <merchantview.h>
 #include <optional>
 #include <sol/sol.hpp>
 #include <spdlog/spdlog.h>
-#include <chatinterf.h>
 
 namespace hooks {
 
@@ -77,7 +82,7 @@ static int getItemTotalCost(const game::StealItemEntry* item)
 
 static const char scenItemCanStealLessCostSum[]{"ITEM_CAN_STEAL_LESS_COST_SUM"};
 
-static constexpr int noItemCostLimit{9999*6};
+static constexpr int noItemCostLimit{9999 * 6};
 
 //
 // ctor hook
@@ -139,7 +144,7 @@ static int getItemCostLimit(const game::IMidgardObjectMap* objectMap)
 // filtering
 //
 
-bool shouldDisplayStealItem(const game::CMidgardID* merchantId, game::StealItemEntry* entry)
+bool shouldDisplayStealItem(game::StealItemEntry* entry)
 {
     if (!entry) {
 
@@ -147,7 +152,6 @@ bool shouldDisplayStealItem(const game::CMidgardID* merchantId, game::StealItemE
 
         return false;
     }
-
 
     //
     // lua load
@@ -157,7 +161,8 @@ bool shouldDisplayStealItem(const game::CMidgardID* merchantId, game::StealItemE
 
         const auto path{scriptsFolder() / "theft.lua"};
 
-        theftFilterItemsMerchantLua = getScriptFunction(path, "theftFilterItemsMerchant", env, false, true);
+        theftFilterItemsMerchantLua = getScriptFunction(path, "theftFilterItemsMerchant", env,
+                                                        false, true);
 
         if (theftFilterItemsMerchantLua) {
 
@@ -169,23 +174,37 @@ bool shouldDisplayStealItem(const game::CMidgardID* merchantId, game::StealItemE
         }
     }
 
-    //
-    // lua
-    //
+    if (!g_stealItemCtx.objectMap) {
+        return false;
+    }
 
+    auto objectMap = g_stealItemCtx.objectMap;
+
+    auto playerObj = objectMap->vftable->findScenarioObjectById(objectMap,
+                                                                &g_stealItemCtx.playerId);
+
+    auto merchantObj = objectMap->vftable->findScenarioObjectById(objectMap,
+                                                                  &g_stealItemCtx.merchantId);
+
+    auto player = static_cast<game::CMidPlayer*>(playerObj);
+
+    auto merchant = static_cast<game::CMidSite*>(merchantObj);
+
+    const auto global = *game::GlobalDataApi::get().getGlobalData();
+    auto item = game::GlobalDataApi::get().findItemById(global->itemTypes, &entry->itemId);
+
+    if (!playerObj || !merchantObj || !item) {
+        return false;
+    }
 
     //
-    // Lua integration is not finished yet.
+    // Lua context
     //
-    // In the future, the item will be exposed to Lua through ItemBaseView,
-    // similar to other scripting hooks. At the moment only itemId and item
-    // value data are considered reliable.
+    // Exposed objects:
     //
-    // merchantId and playerId are currently unresolved and may contain
-    // invalid values (e.g. g00000000). This will be reworked later once
-    // proper context acquisition is implemented.
-    //
-    // For now, Lua filters should only rely on itemId and item value.
+    // player   - PlayerView
+    // merchant - MerchantView
+    // item     - ItemBaseView
     //
     if (theftFilterItemsMerchantLua) {
 
@@ -194,39 +213,32 @@ bool shouldDisplayStealItem(const game::CMidgardID* merchantId, game::StealItemE
             //
             sol::state_view lua(theftFilterItemsMerchantLua->lua_state());
 
-            sol::table ctx = lua.create_table();
+            sol::table stealItemContext = lua.create_table();
 
-            ctx["merchantId"] = merchantId ? idToString(merchantId) : "";
+            stealItemContext["player"] = bindings::PlayerView(player, objectMap);
 
-            ctx["playerId"] = idToString(&g_stealItemCtx.playerId);
+            stealItemContext["merchant"] = bindings::MerchantView(
+                static_cast<const game::CMidSiteMerchant*>(merchant), objectMap);
 
-            ctx["itemId"] = idToString(&entry->itemId);
+            stealItemContext["item"] = bindings::ItemBaseView(item);
 
-            ctx["gold"] = entry->value.gold;
+            sol::object result = (*theftFilterItemsMerchantLua)(stealItemContext);
 
-            auto result = (*theftFilterItemsMerchantLua)(ctx);
-
-            if (result.valid()) {
-
-                bool allowed = result.get<bool>();
-
-                if (allowed) {
-
-                    spdlog::info("[STEAL_ITEM] lua allow");
-
-                } else {
-
-                    spdlog::info("[STEAL_ITEM] lua deny");
-                }
-
-                return allowed;
+            if (result.is<bool>()) {
+                return result.as<bool>();
             }
 
         } catch (const std::exception& e) {
 
             spdlog::info("[STEAL_ITEM] lua exception");
-
             spdlog::info(e.what());
+
+            const auto path{scriptsFolder() / "theft.lua"};
+
+            showErrorMessageBox(fmt::format("Failed to run "
+                                            "'{:s}' script.\n"
+                                            "Reason: '{:s}'",
+                                            path.string(), e.what()));
         }
     }
 
@@ -236,13 +248,11 @@ bool shouldDisplayStealItem(const game::CMidgardID* merchantId, game::StealItemE
 
     const int limit = getItemCostLimit(g_stealItemCtx.objectMap);
 
-
     //
     // disabled
     //
 
     if (limit >= noItemCostLimit) {
-
 
         return true;
     }
@@ -275,7 +285,7 @@ char* __fastcall addStealItemHooked(void* thisptr, void*, game::StealItemEntry* 
     // filter
     //
 
-    if (!shouldDisplayStealItem(&g_stealItemCtx.merchantId, entry)) {
+    if (!shouldDisplayStealItem(entry)) {
         return reinterpret_cast<char*>(thisptr);
     }
 
@@ -284,7 +294,6 @@ char* __fastcall addStealItemHooked(void* thisptr, void*, game::StealItemEntry* 
     //
 
     ++g_stealItemCtx.insertedCount;
-
 
     //
     // original
@@ -302,73 +311,39 @@ game::CMidDragDropInterf* __fastcall stealItemCtorHooked(void* thisptr,
                                                          int a2,
                                                          int functor,
                                                          int a4,
-                                                         void* a5)
+                                                         const game::CMidgardID* merchantId)
 {
     //
     // activate
     //
 
     g_stealItemCtx.active = true;
-
     g_stealItemCtx.insertedCount = 0;
 
     //
-    // object map
+    // context
     //
 
-    auto objectMap = getObjectMap();
+    g_stealItemCtx.objectMap = getObjectMap();
 
-    g_stealItemCtx.objectMap = objectMap;
+    if (merchantId) {
+        g_stealItemCtx.merchantId = *merchantId;
+    }
+
+    auto phaseGame = reinterpret_cast<game::CPhaseGame*>(a4);
+
+    if (phaseGame) {
+
+        if (auto playerId = game::CPhaseApi::get().getCurrentPlayerId(&phaseGame->phase)) {
+            g_stealItemCtx.playerId = *playerId;
+        }
+    }
 
     //
     // original ctor
     //
 
-    auto result = stealItemCtorOrig(thisptr, a2, functor, a4, a5);
-
-    //
-    // merchant
-    //
-    // поправить аналогично заклинаний
-    auto merchantId = game::StealMerchantItemInterfApi::get().getMerchantId(result);
-
-    if (merchantId) {
-
-        g_stealItemCtx.merchantId = *merchantId;
-
-        spdlog::info("[STEAL_ITEM] merchant");
-
-    }
-
-
-    // поправить аналогично заклинаний
-    //
-    // player
-    //
-
-    try {
-
-        auto phaseGame = reinterpret_cast<game::CMidDragDropInterf*>(result)->phaseGame;
-
-        if (phaseGame) {
-
-            auto playerId = game::CPhaseApi::get().getCurrentPlayerId(&phaseGame->phase);
-
-            if (playerId) {
-
-                g_stealItemCtx.playerId = *playerId;
-
-                spdlog::info("[STEAL_ITEM] player");
-
-                spdlog::info(idToString(&g_stealItemCtx.playerId));
-            }
-        }
-
-
-    } catch (...) {
-
-        spdlog::info("[STEAL_ITEM] player failed");
-    }
+    auto result = stealItemCtorOrig(thisptr, a2, functor, a4, merchantId);
 
     //
     // final state
@@ -384,25 +359,20 @@ game::CMidDragDropInterf* __fastcall stealItemCtorHooked(void* thisptr,
 
         auto popup = reinterpret_cast<game::CMidPopupInterf*>(result);
 
-        if (!popup || !popup->popupData) {
-            return result;
-        }
+        if (popup && popup->popupData) {
 
-        auto dialog = popup->popupData->dialog;
+            auto dialog = popup->popupData->dialog;
 
-        if (dialog) {
+            if (dialog) {
 
-            const auto& dlgApi = game::CDialogInterfApi::get();
+                const auto& dlgApi = game::CDialogInterfApi::get();
 
-            auto okBtn = dlgApi.findButton(dialog, "BTN_YES");
-
-            if (okBtn) {
-                okBtn->vftable->setEnabled(okBtn, false);
+                if (auto okBtn = dlgApi.findButton(dialog, "BTN_YES")) {
+                    okBtn->vftable->setEnabled(okBtn, false);
+                }
             }
         }
     }
-
-   
 
     //
     // cleanup

--- a/mss32/src/stealmerchantiteminterf.cpp
+++ b/mss32/src/stealmerchantiteminterf.cpp
@@ -24,40 +24,8 @@
 #include "version.h"
 
 #include <array>
-#include <cstdint>
 
 namespace game::StealMerchantItemInterfApi {
-
-//
-// helper wrappers
-//
-
-static game::CMidgardID* __fastcall getMerchantIdImpl(void* thisptr, void*)
-{
-    //
-    // asm:
-    //
-    // mov edi, [esi+20h]
-    //
-
-    auto merchantId = *reinterpret_cast<void**>(reinterpret_cast<std::uint8_t*>(thisptr) + 0x20);
-
-    return reinterpret_cast<game::CMidgardID*>(merchantId);
-}
-
-static void* __fastcall getItemVectorImpl(void* thisptr, void*)
-{
-    //
-    // asm:
-    //
-    // mov ecx, [esi+20h]
-    // add ecx, 0Ch
-    //
-
-    auto interfaceData = *reinterpret_cast<void**>(reinterpret_cast<std::uint8_t*>(thisptr) + 0x20);
-
-    return reinterpret_cast<void*>(reinterpret_cast<std::uint8_t*>(interfaceData) + 0x0C);
-}
 
 // clang-format off
 
@@ -67,40 +35,28 @@ static std::array<Api, 4> functions = {{
     Api{
         (Api::Constructor)0x4A519E,
         (Api::GetListBox)0x4A56CE,
-        (Api::AddStealItem)0x4A5BCA,
-
-        (Api::GetMerchantId)getMerchantIdImpl,
-        (Api::GetItemVector)getItemVectorImpl,
+        (Api::AddStealItem)0x4A5BCA
     },
 
     // Russobit
     Api{
         (Api::Constructor)0x4A519E,
         (Api::GetListBox)0x4A56CE,
-        (Api::AddStealItem)0x4A5BCA,
-
-        (Api::GetMerchantId)getMerchantIdImpl,
-        (Api::GetItemVector)getItemVectorImpl,
+        (Api::AddStealItem)0x4A5BCA
     },
 
     // Gog
     Api{
         (Api::Constructor)0x4A4A1F,
         (Api::GetListBox)0x4A4F2F,
-        (Api::AddStealItem)0x4A542B,
-
-        (Api::GetMerchantId)getMerchantIdImpl,
-        (Api::GetItemVector)getItemVectorImpl,
+        (Api::AddStealItem)0x4A542B
     },
 
     // Scenario Editor
     Api{
         (Api::Constructor)nullptr,
         (Api::GetListBox)nullptr,
-        (Api::AddStealItem)nullptr,
-
-        (Api::GetMerchantId)nullptr,
-        (Api::GetItemVector)nullptr,
+        (Api::AddStealItem)nullptr
     }
 
 }};


### PR DESCRIPTION
## Summary

This PR completes the Lua API for thief mechanics and brings merchant item and mage tower spell filters to feature parity with the rest of the scripting API.

### Changes

- restored specialized `MerchantView` and `MageTowerView` contexts for theft callbacks;
- exposed merchant inventory and mage tower spell lists to Lua;
- added global lookup APIs:
  - `getGlobal().items:getBase()`
  - `getGlobal().spells:get()`
- fixed missing Lua view bindings and registration;
- improved Lua error handling by displaying script errors in message boxes;
- updated `theft.lua` examples and `luaApi.md` documentation;
- made merchant item and spell filter callbacks fully functional and consistent with the existing scripting API.